### PR TITLE
fix: three correctness/reliability bugs

### DIFF
--- a/crates/dbtools/src/analytics/get_biggest_programs.rs
+++ b/crates/dbtools/src/analytics/get_biggest_programs.rs
@@ -20,11 +20,19 @@ pub async fn get_biggest_programs(database_url: &str) {
     println!("########################################################");
     println!("Getting biggest programs from snapshot accounts partitions");
     println!("########################################################");
+
+    let partition_rows = db
+        .query_all(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'snapshot_accounts_p%' ORDER BY tablename",
+        ))
+        .await
+        .expect("Failed to query pg_tables for snapshot_accounts partitions");
+
     let mut owners = Vec::new();
-    for partition in 0..64 {
-        let partition_owners =
-            get_biggest_programs_from_table(&db, &format!("snapshot_accounts_p{}", partition))
-                .await;
+    for row in partition_rows {
+        let table: String = row.try_get("", "tablename").unwrap();
+        let partition_owners = get_biggest_programs_from_table(&db, &table).await;
         if let Some(biggest_owner) = partition_owners.first() {
             owners.push(biggest_owner.to_string());
         }

--- a/crates/query-tracker/src/tracker.rs
+++ b/crates/query-tracker/src/tracker.rs
@@ -142,7 +142,7 @@ pub fn track_program_accounts_query(
                             }
                         }
 
-                        if !found && *count == threshold {
+                        if !found {
                             temp_vec.push(PrioritizedQuery {
                                 count: *count,
                                 key: key_for_queue,

--- a/example.cloudbreak.index.toml
+++ b/example.cloudbreak.index.toml
@@ -38,7 +38,9 @@ chunk-size = 1000
 max-chunk-bytes-data = 2097152
 # The max number of grpc errors before trying to reconnect
 #  (it will always reconnect on a single stream `None`)
-max-grpc-errors = 1
+#  Keeping this at 10 or higher; setting it to 1 causes the indexer to exit on
+#  the first transient gRPC hiccup (e.g. a brief network blip).
+max-grpc-errors = 10
 # The buffer size for queuing subscription events
 channel-size = 1000
 


### PR DESCRIPTION


- **query-tracker**: auto-index silently never fired when a batch flush pushed the count past the threshold in one go (e.g. 0→15 with threshold=10). The inner `== threshold` guard was redundant — the outer `>= threshold` check already covers it — and was the only thing blocking the entry from being added to the priority queue. Dropped it.
Fixes: #2 

- **example config**: `max-grpc-errors = 1` caused the indexer to die on the first transient gRPC hiccup. Changed to `10` and added a comment so new operators know why it matters.
Fixes: #3 

- **dbtools `get-biggest-programs`**: hardcoded `0..64` partition loop panicked for anyone on the default 10-partition HASH layout (`snapshot_accounts_p10` doesn't exist). Now reads actual partitions from `pg_tables`.
Fixes: #4 