### PR TITLE
fix: get-biggest-programs panics on non-64-partition layouts

### DIFF
--- a/crates/dbtools/src/analytics/get_biggest_programs.rs
+++ b/crates/dbtools/src/analytics/get_biggest_programs.rs
@@ -20,11 +20,19 @@ pub async fn get_biggest_programs(database_url: &str) {
     println!("########################################################");
     println!("Getting biggest programs from snapshot accounts partitions");
     println!("########################################################");
+
+    let partition_rows = db
+        .query_all(Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'snapshot_accounts_p%' ORDER BY tablename",
+        ))
+        .await
+        .expect("Failed to query pg_tables for snapshot_accounts partitions");
+
     let mut owners = Vec::new();
-    for partition in 0..64 {
-        let partition_owners =
-            get_biggest_programs_from_table(&db, &format!("snapshot_accounts_p{}", partition))
-                .await;
+    for row in partition_rows {
+        let table: String = row.try_get("", "tablename").unwrap();
+        let partition_owners = get_biggest_programs_from_table(&db, &table).await;
         if let Some(biggest_owner) = partition_owners.first() {
             owners.push(biggest_owner.to_string());
         }


### PR DESCRIPTION
`get-biggest-programs` iterated a hardcoded `0..64` range to query `snapshot_accounts_p0` through `snapshot_accounts_p63`. Anyone on the default 10-partition HASH layout only has `p0`–`p9`, so the tool panicked the moment it hit `snapshot_accounts_p10`.

Fixed by querying `pg_tables` for the actual `snapshot_accounts_p*` partitions instead of assuming 64. Works correctly regardless of partition count.

Closes #4 