### PR TITLE
fix: auto-index silently never fires on batched increments

### DIFF
--- a/crates/query-tracker/src/tracker.rs
+++ b/crates/query-tracker/src/tracker.rs
@@ -142,7 +142,7 @@ pub fn track_program_accounts_query(
                             }
                         }
 
-                        if !found && *count == threshold {
+                        if !found && *count < threshold + increment {
                             temp_vec.push(PrioritizedQuery {
                                 count: *count,
                                 key: key_for_queue,


### PR DESCRIPTION
`*count == threshold` only matched when the count landed exactly on the threshold, which worked for one-by-one increments but silently dropped entries when a batch flush pushed the count past it in one go (e.g. 0→15 with threshold=10).

Changed to `*count < threshold + increment` — equivalent to checking `previous_count < threshold` — so the entry is added to the priority queue on the genuine first crossing, regardless of batch size, without re-triggering after the queue consumes it.

Closes: #2 