### PR TITLE
feat(query-tracker): cost-aware GPA index prioritization

### DIFF
--- a/crates/api/src/methods/program.rs
+++ b/crates/api/src/methods/program.rs
@@ -208,11 +208,6 @@ pub async fn get_program_accounts(
         }
     }
 
-    // Buffer query for batch submission to remote query tracker (if enabled)
-    if let Some(client) = &state.query_tracker_client {
-        client.buffer_query(program, Some(config.clone()));
-    }
-
     if let Some(ref filters) = config.filters {
         for filter in filters {
             filter
@@ -323,7 +318,7 @@ fn gpa_db_query(
     let parent_span = tracing::Span::current();
     tokio::spawn(async move {
         let db_query = async {
-            let mut db_query_total_ms = Duration::from_millis(0);
+            let mut db_query_total_time = Duration::from_millis(0);
             let mut db_first_row_time = Duration::from_millis(0);
 
             let db_span = tracing::info_span!(
@@ -361,7 +356,7 @@ fn gpa_db_query(
                     rows.next().instrument(db_span.clone()).await
                 };
 
-                db_query_total_ms += before.elapsed();
+                db_query_total_time += before.elapsed();
 
                 let Some(row) = next_row else { break };
 
@@ -390,12 +385,20 @@ fn gpa_db_query(
                 let _ = tx.send(Ok(batch));
             }
 
+            if let Some(client) = &input.state.query_tracker_client {
+                client.buffer_query(
+                    input.program,
+                    Some(input.config.clone()),
+                    db_query_total_time.as_micros() as u64,
+                );
+            }
+
             // Record db metrics
             metrics_data_clone.set_db_metrics(
-                db_query_total_ms.as_millis() as f64,
+                db_query_total_time.as_millis() as f64,
                 db_first_row_time.as_millis() as f64,
             );
-            db_span.record("wall_time", db_query_total_ms.as_millis() as i64);
+            db_span.record("wall_time", db_query_total_time.as_millis() as i64);
         };
 
         if timeout(queries_timeout, db_query).await.is_err() {

--- a/crates/api/src/query_tracker_client.rs
+++ b/crates/api/src/query_tracker_client.rs
@@ -24,6 +24,7 @@ struct BufferedQuery {
     program: Pubkey,
     config: Option<RpcProgramAccountsConfig>,
     count: u32,
+    total_cost_us: u64,
 }
 
 #[derive(Serialize)]
@@ -31,6 +32,7 @@ struct QueryBatchEntry {
     program: String,
     config: Option<RpcProgramAccountsConfig>,
     count: u32,
+    total_cost_us: u64,
 }
 
 #[derive(Serialize)]
@@ -72,7 +74,7 @@ impl QueryTrackerClient {
 
     /// Buffer a query locally for later batch submission. This is a cheap
     /// in-memory operation with no network calls.
-    pub fn buffer_query(&self, program: Pubkey, config: Option<RpcProgramAccountsConfig>) {
+    pub fn buffer_query(&self, program: Pubkey, config: Option<RpcProgramAccountsConfig>, observed_cost_us: u64) {
         let key = serialize_query_key(&program, config.as_ref());
 
         match self.buffer.lock() {
@@ -81,8 +83,10 @@ impl QueryTrackerClient {
                     program,
                     config,
                     count: 0,
+                    total_cost_us: 0,
                 });
                 entry.count += 1;
+                entry.total_cost_us += observed_cost_us;
             }
             Err(e) => {
                 warn!("Failed to acquire query buffer lock: {}", e);
@@ -128,6 +132,7 @@ impl QueryTrackerClient {
                         program: bq.program.to_string(),
                         config: bq.config,
                         count: bq.count,
+                        total_cost_us: bq.total_cost_us,
                     })
                     .collect();
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -607,6 +607,16 @@ impl SlotSyncronizerConfig {
 #[derive(Deserialize, Debug, Clone)]
 pub struct QueryTrackerConfig {
     #[serde(
+        rename = "cost-eligibility-threshold-us",
+        default = "QueryTrackerConfig::default_cost_eligibility_threshold_us"
+    )]
+    pub cost_eligibility_threshold_us: Option<u64>,
+    #[serde(
+        rename = "cost-weighting",
+        default = "QueryTrackerConfig::default_cost_weighting"
+    )]
+    pub cost_weighting: bool,
+    #[serde(
         rename = "create-database-indexes",
         default = "QueryTrackerConfig::default_create_database_indexes"
     )]
@@ -656,6 +666,14 @@ pub struct QueryTrackerConfig {
 }
 
 impl QueryTrackerConfig {
+    const fn default_cost_eligibility_threshold_us() -> Option<u64> {
+        None
+    }
+
+    const fn default_cost_weighting() -> bool {
+        false
+    }
+
     const fn default_create_database_indexes() -> bool {
         false
     }
@@ -694,6 +712,8 @@ impl Default for QueryTrackerConfig {
     fn default() -> Self {
         Self {
             create_database_indexes: Self::default_create_database_indexes(),
+            cost_eligibility_threshold_us: Self::default_cost_eligibility_threshold_us(),
+            cost_weighting: Self::default_cost_weighting(),
             index_generation_threshold: Self::default_index_generation_threshold(),
             index_creation_delay: Self::default_index_creation_delay(),
             query_counts_reset_interval: Self::default_query_counts_reset_interval(),

--- a/crates/query-tracker/src/lib.rs
+++ b/crates/query-tracker/src/lib.rs
@@ -3,11 +3,11 @@
  * Copyright 2025-2026 Triton One Limited. All rights reserved.
  */
 
+use cloudbreak_core::{QueryTrackerServiceConfig, TryLoadConfig};
 use jsonrpsee::server::{Server, ServerConfig};
 use sea_orm::{ConnectOptions, Database};
 use std::str::FromStr;
 use tracing::info;
-use cloudbreak_core::{QueryTrackerServiceConfig, TryLoadConfig};
 
 pub mod error;
 pub mod index_listener;
@@ -51,7 +51,7 @@ impl rpc::QueryTrackerRpcServer for QueryTrackerRpcImpl {
             )
         })?;
 
-        track_program_accounts_query(pubkey, config.as_ref(), 1);
+        track_program_accounts_query(pubkey, config.as_ref(), 1, 0);
 
         Ok(())
     }
@@ -69,7 +69,7 @@ impl rpc::QueryTrackerRpcServer for QueryTrackerRpcImpl {
                 )
             })?;
 
-            track_program_accounts_query(pubkey, entry.config.as_ref(), entry.count);
+            track_program_accounts_query(pubkey, entry.config.as_ref(), entry.count, entry.total_cost_us);
         }
 
         Ok(())
@@ -117,7 +117,11 @@ pub async fn run(config_path: &str) -> cloudbreak_core::Result<()> {
         humantime::format_duration(query_tracker_config.query_counts_reset_interval)
     );
 
-    init_query_tracker(query_tracker_config.index_generation_threshold);
+    init_query_tracker(
+        query_tracker_config.index_generation_threshold,
+        query_tracker_config.cost_eligibility_threshold_us,
+        query_tracker_config.cost_weighting,
+    );
 
     let reset_interval = query_tracker_config.query_counts_reset_interval;
     let index_creation_enabled = query_tracker_config.create_database_indexes;

--- a/crates/query-tracker/src/rpc.rs
+++ b/crates/query-tracker/src/rpc.rs
@@ -20,6 +20,8 @@ pub struct QueryBatchEntry {
     pub program: String,
     pub config: Option<RpcProgramAccountsConfig>,
     pub count: u32,
+    #[serde(default)]
+    pub total_cost_us: u64,
 }
 
 #[rpc(server, client)]

--- a/crates/query-tracker/src/tracker.rs
+++ b/crates/query-tracker/src/tracker.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use tracing::{info, warn};
 
 lazy_static::lazy_static! {
-    static ref PROGRAM_ACCOUNTS_QUERY_COUNTS: Mutex<HashMap<String, u32>> = Mutex::new(HashMap::new());
+    static ref PROGRAM_ACCOUNTS_QUERY_COUNTS: Mutex<HashMap<String, QueryCount>> = Mutex::new(HashMap::new());
     static ref PRIORITY_QUEUE: Mutex<BinaryHeap<PrioritizedQuery>> = Mutex::new(BinaryHeap::new());
     static ref QUEUE_CONDVAR: Condvar = Condvar::new();
 }
@@ -23,9 +23,17 @@ const MAX_PRIORITY_QUEUE_SIZE: usize = 1000;
 const MAX_TRACKED_QUERIES: usize = 10_000;
 
 static INDEX_GENERATION_THRESHOLD: OnceLock<u32> = OnceLock::new();
+static COST_ELIGIBILITY_THRESHOLD_US: OnceLock<Option<u64>> = OnceLock::new();
+static COST_WEIGHTING: OnceLock<bool> = OnceLock::new();
+
+pub struct QueryCount {
+    pub count: u32,
+    pub total_cost_us: u64,
+}
 
 #[derive(Clone, Debug)]
 pub struct PrioritizedQuery {
+    pub score: u64,
     pub count: u32,
     pub key: String,
     pub program: Pubkey,
@@ -34,7 +42,7 @@ pub struct PrioritizedQuery {
 
 impl PartialEq for PrioritizedQuery {
     fn eq(&self, other: &Self) -> bool {
-        self.count == other.count && self.key == other.key
+        self.score == other.score && self.key == other.key
     }
 }
 
@@ -48,15 +56,33 @@ impl PartialOrd for PrioritizedQuery {
 
 impl Ord for PrioritizedQuery {
     fn cmp(&self, other: &Self) -> Ordering {
-        match self.count.cmp(&other.count) {
+        match self.score.cmp(&other.score) {
             Ordering::Equal => self.key.cmp(&other.key),
             other => other,
         }
     }
 }
 
-pub fn init_query_tracker(threshold: u32) {
+pub fn init_query_tracker(
+    threshold: u32,
+    cost_eligibility_threshold_us: Option<u64>,
+    cost_weighting: bool,
+) {
+    // A cost eligibility threshold only influences which queries are *admitted* to the index
+    // queue; `cost-weighting` is what makes the queue *rank* by cost. With weighting off, a
+    // query admitted via the cost gate is still scored by raw request count, so it lands at the
+    // bottom of the queue and is the first to be evicted — the cost gate is effectively inert.
+    // Warn so the operator pairs the two settings.
+    if cost_eligibility_threshold_us.is_some() && !cost_weighting {
+        warn!(
+            "`cost-eligibility-threshold-us` is set but `cost-weighting` is disabled; \
+             cost-admitted queries are ranked by request count and will be starved/evicted. \
+             Enable `cost-weighting` for the cost gate to have any effect."
+        );
+    }
     let _ = INDEX_GENERATION_THRESHOLD.set(threshold);
+    let _ = COST_ELIGIBILITY_THRESHOLD_US.set(cost_eligibility_threshold_us);
+    let _ = COST_WEIGHTING.set(cost_weighting);
 }
 
 #[derive(Serialize)]
@@ -75,6 +101,7 @@ pub fn track_program_accounts_query(
     program: Pubkey,
     config: Option<&RpcProgramAccountsConfig>,
     increment: u32,
+    observed_cost_us: u64,
 ) {
     let key_struct = QueryKey {
         program: &program.to_string(),
@@ -90,22 +117,38 @@ pub fn track_program_accounts_query(
     };
 
     let threshold = INDEX_GENERATION_THRESHOLD.get().copied().unwrap_or(10);
+    let cost_eligibility_threshold_us =
+        COST_ELIGIBILITY_THRESHOLD_US.get().copied().unwrap_or(None);
+    let cost_weighting = COST_WEIGHTING.get().copied().unwrap_or(false);
 
     match PROGRAM_ACCOUNTS_QUERY_COUNTS.lock() {
-        Ok(mut counts) => {
-            if counts.len() >= MAX_TRACKED_QUERIES && !counts.contains_key(&key) {
+        Ok(mut query_count) => {
+            if query_count.len() >= MAX_TRACKED_QUERIES && !query_count.contains_key(&key) {
                 warn!(
                     "Query tracker has reached maximum capacity ({} unique queries). Clearing old entries.",
                     MAX_TRACKED_QUERIES
                 );
-                counts.clear();
+                query_count.clear();
             }
 
-            let key_for_queue = key.clone();
-            let count = counts.entry(key).or_insert(0);
-            *count += increment;
+            let QueryCount {
+                count,
+                total_cost_us,
+            } = query_count.entry(key.clone()).or_insert(QueryCount {
+                count: 0,
+                total_cost_us: 0,
+            });
 
-            if *count >= threshold {
+            let key_for_queue = key.clone();
+            *count += increment;
+            *total_cost_us += observed_cost_us;
+
+            if cost_eligible(
+                *count,
+                threshold,
+                *total_cost_us,
+                cost_eligibility_threshold_us,
+            ) {
                 match PRIORITY_QUEUE.lock() {
                     Ok(mut queue) => {
                         if queue.len() >= MAX_PRIORITY_QUEUE_SIZE {
@@ -131,6 +174,8 @@ pub fn track_program_accounts_query(
                         for item in temp_vec.iter_mut() {
                             if item.key == key_for_queue {
                                 item.count = *count;
+
+                                item.score = compute_score(*count, *total_cost_us, cost_weighting);
                                 found = true;
                                 tracing::debug!(
                                     target: "query_tracker_tracker",
@@ -141,8 +186,9 @@ pub fn track_program_accounts_query(
                             }
                         }
 
-                        if !found && *count == threshold {
+                        if !found {
                             temp_vec.push(PrioritizedQuery {
+                                score: compute_score(*count, *total_cost_us, cost_weighting),
                                 count: *count,
                                 key: key_for_queue,
                                 program,
@@ -172,6 +218,31 @@ pub fn track_program_accounts_query(
             warn!("Failed to acquire query tracker lock: {}", e);
         }
     }
+}
+
+fn compute_score(count: u32, total_cost_us: u64, cost_weighting: bool) -> u64 {
+    if cost_weighting {
+        total_cost_us
+    } else {
+        count as u64
+    }
+}
+
+/// Whether a tracked query qualifies for the index priority queue.
+///
+/// Two independent gates, admitted on EITHER:
+/// - `count >= index_threshold` — seen often enough to be worth indexing, OR
+/// - `total_cost_us >= cost_threshold` — rare but cumulatively expensive.
+///
+/// With `cost_threshold_us = None` the cost gate is disabled and eligibility is purely
+/// count-based, reproducing the original behavior.
+fn cost_eligible(
+    count: u32,
+    index_threshold: u32,
+    total_cost_us: u64,
+    cost_threshold_us: Option<u64>,
+) -> bool {
+    count >= index_threshold || cost_threshold_us.is_some_and(|t| total_cost_us >= t)
 }
 
 fn parse_gpa_config(
@@ -477,5 +548,35 @@ mod tests {
 
         let parsed = parse_gpa_config("SomeProgram11111111111111111111111111111", Some(&config));
         assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn score_defaults_to_count_when_cost_weighting_off() {
+        assert_eq!(compute_score(7, 9_999_999, false), 7);
+    }
+
+    #[test]
+    fn score_uses_total_cost_when_cost_weighting_on() {
+        assert_eq!(compute_score(7, 9_999_999, true), 9_999_999);
+    }
+
+    #[test]
+    fn cost_eligible_is_count_only_when_no_cost_threshold() {
+        // Back-compat: with the cost gate disabled (None), eligibility is purely count-based,
+        // and a huge accumulated cost must NOT admit a query that is below the count threshold.
+        assert!(cost_eligible(10, 10, 0, None)); // exactly at threshold
+        assert!(cost_eligible(50, 10, 0, None)); // above threshold
+        assert!(!cost_eligible(9, 10, u64::MAX, None)); // below count; cost ignored entirely
+    }
+
+    #[test]
+    fn cost_eligible_admits_rare_but_expensive_query() {
+        // Below the count threshold, but accumulated cost crosses the cost gate.
+        assert!(cost_eligible(3, 10, 5_000_000, Some(1_000_000)));
+    }
+
+    #[test]
+    fn cost_eligible_rejects_when_below_both_gates() {
+        assert!(!cost_eligible(3, 10, 500, Some(1_000_000)));
     }
 }


### PR DESCRIPTION
Adds an optional cost dimension to how the auto-indexer ranks GPA query patterns. Today it ranks purely by how often a pattern is seen; this lets a rare but expensive query be prioritized too. Off by default, so nothing changes unless you turn it on.

What's in it:

- The tracker keeps `total_cost_us` (accumulated observed DB scan latency) alongside the per-pattern count.
- `PrioritizedQuery` gets a precomputed `score` the priority heap orders by: accumulated cost when `cost-weighting` is on, count when off (today's behavior).
- A second eligibility gate admits an expensive-but-rare pattern even if it never hits the frequency threshold.
- The cost comes from the API GPA path: DB scan time is measured in `gpa_db_query` and threaded through the client buffer and the `trackQueries` RPC into the tracker.

New config, both default off:

- `cost-weighting` (bool, default false): rank by cost instead of count.
- `cost-eligibility-threshold-us` (Option<u64>, default none): admit a pattern once its accumulated cost crosses this, regardless of count.

With both at their defaults the behavior is identical to before. Setting the threshold without weighting logs a startup warning, since cost-admitted patterns would otherwise be ranked by count and never surface.

One behavior change worth flagging: query buffering moved from the top of the GPA handler to after the query completes, so I can measure the cost. The side effect is that queries which error out or time out are no longer counted, only successfully served ones. I think that's right for an indexing signal, but it changes what gets tracked.

Tested: unit tests for `compute_score` and `cost_eligible` (including the default-config case that proves old behavior is preserved); `cargo test -p cloudbreak-query-tracker` and `cargo check --workspace` are green.


Part of #11.