### PR TITLE
feat(api): add getTokenSupply RPC method

### DIFF
--- a/crates/api/src/http/rpc.rs
+++ b/crates/api/src/http/rpc.rs
@@ -4,12 +4,12 @@
  */
 
 use bytes::Bytes;
+use cloudbreak_core::modules::rpc_filter_type::RpcProgramAccountsConfig;
 use http_body_util::combinators::UnsyncBoxBody;
 use hyper::body::Incoming;
 use hyper::{Request, StatusCode};
 use serde::Serialize;
 use solana_commitment_config::CommitmentConfig;
-use cloudbreak_core::modules::rpc_filter_type::RpcProgramAccountsConfig;
 use solana_rpc_client_api::config::{RpcAccountInfoConfig, RpcContextConfig};
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -408,6 +408,45 @@ async fn process_single_request(
             metrics::CLOUDBREAK_API_REQUEST_DURATION_MS
                 .with_label_values(&[
                     "getTokenAccountBalance",
+                    metrics::bytes_bucket(json_response.len() as u64),
+                ])
+                .observe(start_time.elapsed().as_millis() as f64);
+
+            json_response
+        }
+        "getTokenSupply" => {
+            let start_time = Instant::now();
+
+            let pubkey: String = match extract_param(&rpc_request.params, 0) {
+                Ok(p) => p,
+                Err(e) => return make_error_response(id, -32602, e),
+            };
+
+            let commitment: Option<CommitmentConfig> =
+                extract_param(&rpc_request.params, 1).ok().flatten();
+
+            let result =
+                methods::get_token_supply::get_token_supply(state, pubkey, commitment).await;
+
+            let status_label = if result.is_ok() {
+                "success"
+            } else {
+                tracing::error!(
+                    target: "api_request_errors_count",
+                    "getTokenSupply error: {:?}",
+                    result.as_ref().unwrap_err()
+                );
+                "error"
+            };
+            metrics::CLOUDBREAK_API_REQUESTS_TOTAL
+                .with_label_values(&["getTokenSupply", status_label])
+                .inc();
+
+            let json_response = json_serialize_response(id, result).await;
+
+            metrics::CLOUDBREAK_API_REQUEST_DURATION_MS
+                .with_label_values(&[
+                    "getTokenSupply",
                     metrics::bytes_bucket(json_response.len() as u64),
                 ])
                 .observe(start_time.elapsed().as_millis() as f64);

--- a/crates/api/src/methods/get_token_supply.rs
+++ b/crates/api/src/methods/get_token_supply.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+use cloudbreak_entity::slots;
+use sea_orm::EntityTrait;
+use sea_orm::sqlx::Row;
+use sea_orm::sqlx::{self};
+use solana_account_decoder::parse_token::token_amount_to_ui_amount_v3;
+use solana_account_decoder_client_types::token::UiTokenAmount;
+use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
+use solana_pubkey::Pubkey;
+use solana_rpc_client_api::response::{Response as RpcResponse, RpcResponseContext};
+use spl_token_2022::extension::StateWithExtensions;
+use spl_token_2022::state::Mint;
+use tokio::time::timeout;
+use tracing::Instrument;
+
+use crate::error::RpcError;
+use crate::http::CloudbreakRpcState;
+use crate::methods::token::parse_additional_mint_data;
+use crate::methods::{is_token_program, resolve_commitment};
+use crate::{db_query, metrics};
+
+#[tracing::instrument(name = "get_token_supply_rpc", skip_all, fields(pubkey = %mint))]
+pub async fn get_token_supply(
+    state: &CloudbreakRpcState,
+    mint: String,
+    commitment: Option<CommitmentConfig>,
+) -> Result<RpcResponse<UiTokenAmount>, RpcError> {
+    let _guard = metrics::InFlightRequestGuard::new("getTokenSupply");
+
+    let pubkey: Pubkey = mint
+        .parse()
+        .map_err(|_| RpcError::PubkeyValidationError(mint.clone()))?;
+
+    let commitment = commitment
+        .map(|commitment_config| {
+            resolve_commitment(commitment_config.commitment, state.processed_commitment)
+        })
+        .transpose()?
+        .unwrap_or(CommitmentLevel::Finalized);
+
+    let (latest_slot, block_time): (u64, i64) = match &state.slot_syncronizer_data {
+        Some(data) => {
+            let data = data.read().expect("Failed to read slot syncronizer data");
+            (
+                data.get_slot_for_commitment(commitment),
+                data.get_block_time_for_commitment(commitment),
+            )
+        }
+        None => {
+            let slot_model = slots::Entity::find_by_id(commitment as i32)
+                .one(&state.database)
+                .instrument(tracing::info_span!("slot_db"))
+                .await?;
+
+            let model = slot_model.ok_or(RpcError::InternalError)?;
+            (model.slot as u64, model.block_time)
+        }
+    };
+
+    let sql_template = include_str!("../db/getAccountInfo.sql");
+    let pubkey_hex = format!("'\\x{}'::bytea", hex::encode(pubkey.as_ref()));
+    let sql = sql_template.replace("$1", &pubkey_hex);
+    let sql = sql.replace("$2", &latest_slot.to_string());
+    let sql = db_query::add_trace_traceparent_to_query(&sql);
+
+    tracing::debug!(target: "get_token_supply_sql", "## sql: {}", sql);
+
+    let pool = state.database.get_postgres_connection_pool();
+    let rows = timeout(state.queries_timeout, async {
+        let span = tracing::info_span!("get_token_supply_db");
+        sqlx::raw_sql(&sql).fetch_all(pool).instrument(span).await
+    })
+    .await
+    .map_err(|_elapsed| {
+        tracing::error!("getTokenSupply query timed out");
+        RpcError::InternalError
+    })?
+    .map_err(|e| {
+        tracing::error!("Database query error: {}", e);
+        RpcError::InternalError
+    })?;
+
+    let Some(row) = rows.first() else {
+        // Account not in DB (or its latest version was closed)
+        return Err(RpcError::AccountNotFound {
+            pubkey: pubkey.to_string(),
+        });
+    };
+
+    let owner_bytes: Vec<u8> = row.get("owner");
+    let owner = Pubkey::try_from(owner_bytes.as_slice()).map_err(|_| RpcError::InternalError)?;
+
+    if !state.indexer_filter.is_program_selected(&owner) {
+        return Err(RpcError::AccountOwnerExcluded {
+            pubkey: pubkey.to_string(),
+            owner: owner.to_string(),
+        });
+    }
+
+    if !is_token_program(&owner) {
+        return Err(RpcError::NotATokenAccount {
+            pubkey: pubkey.to_string(),
+        });
+    }
+
+    let data: Vec<u8> = row.get("data");
+
+    let mint_state =
+        StateWithExtensions::<Mint>::unpack(&data).map_err(|_| RpcError::MintDataNotFound {
+            mint: pubkey.to_string(),
+        })?;
+
+    let supply = mint_state.base.supply;
+    let additional_mint_data = parse_additional_mint_data(&pubkey, &data, block_time);
+    let additional_data = additional_mint_data
+        .as_ref()
+        .and_then(|d| d.spl_token_additional_data.as_ref())
+        .ok_or_else(|| RpcError::MintDataNotFound {
+            mint: pubkey.to_string(),
+        })?;
+
+    let ui_token_amount = token_amount_to_ui_amount_v3(supply, additional_data);
+
+    Ok(RpcResponse {
+        context: RpcResponseContext {
+            slot: latest_slot,
+            api_version: None,
+        },
+        value: ui_token_amount,
+    })
+}

--- a/crates/api/src/methods/mod.rs
+++ b/crates/api/src/methods/mod.rs
@@ -3,10 +3,10 @@
  * Copyright 2025-2026 Triton One Limited. All rights reserved.
  */
 
-use solana_commitment_config::CommitmentLevel;
-use solana_pubkey::Pubkey;
 use cloudbreak_core::ProcessedCommitmentBehavior;
 use cloudbreak_core::modules::rpc_filter_type::RpcFilterType;
+use solana_commitment_config::CommitmentLevel;
+use solana_pubkey::Pubkey;
 
 use crate::error::RpcError;
 
@@ -15,6 +15,7 @@ pub mod get_account_info;
 pub mod get_balance;
 pub mod get_multiple_accounts;
 pub mod get_token_account_balance;
+pub mod get_token_supply;
 pub mod mint;
 pub mod mint_accounts;
 pub mod program;


### PR DESCRIPTION
## What this adds

Implements `getTokenSupply`, one of the SPL token RPC methods that wasn't wired up yet. You pass a mint and get back its total supply as a `UiTokenAmount` (amount, decimals, uiAmount, uiAmountString), the same shape Agave returns.

## How it works

It follows the existing `getTokenAccountBalance` handler pretty closely, since most of the moving parts are the same:

1. Parse and validate the mint pubkey.
2. Resolve the slot and block time for the requested commitment, from the slot syncronizer if it's enabled, otherwise from the slots table.
3. Look the account up by its pubkey at that slot with `getAccountInfo.sql`.
4. Guard the result. Not in the DB gives AccountNotFound, an owner that isn't in the index filter gives AccountOwnerExcluded, and an owner that isn't a token program gives an invalid-param error.
5. Unpack the mint, read `supply`, and run it through `token_amount_to_ui_amount_v3` using the same additional-mint-data path the balance handler uses, so Token-2022 extensions like interest-bearing and scaled-ui-amount go through the exact same logic they do there.

Then I registered the method in `methods/mod.rs` and added the dispatch arm in `http/rpc.rs`, modeled on the `getTokenAccountBalance` arm with the same param extraction, request metrics and duration histogram.

## Why reuse getAccountInfo.sql

`getTokenSupply` is just a lookup by the mint's own address, which is exactly what `getAccountInfo.sql` already does: a lookup by pubkey on the (pubkey, slot) index that returns the one latest row. The owner and is-token-program checks then happen in Rust. If the owner isn't a token program, it's rejected there, and if it is a token program but the bytes don't unpack as a mint, the unpack step rejects it. So I didn't need to write any new SQL.

## How I tested it

Ran it end-to-end against a running API on real data:

- A valid mint returns the correct supply, decimals and uiAmount.
- A pubkey that isn't in the DB returns AccountNotFound.
- A malformed pubkey returns the invalid-param error.

No automated tests in this PR because the crate doesn't currently have unit tests for these handlers (the sibling `getTokenAccountBalance` has none either). If you want it covered, I can add a getTokenSupply arm to the integration_tests compare harness so it gets diffed against a reference RPC as getTokenAccountBalance does. Just let me know.

## Scope

Three files: the new handler, the module registration, and the dispatch arm. Nothing else touched.
