### PR TITLE
feat(api): add getTokenLargestAccounts RPC method

### DIFF
--- a/crates/api/src/db/getTokenLargestAccounts.sql
+++ b/crates/api/src/db/getTokenLargestAccounts.sql
@@ -1,0 +1,64 @@
+-- SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+WITH all_versions AS (
+    SELECT
+        accounts.pubkey,
+        accounts.owner,
+        accounts.lamports,
+        accounts.slot,
+        accounts.data,
+        accounts.token_mint
+    FROM accounts
+    WHERE
+        accounts.token_mint = $1
+        AND accounts.slot <= $2
+    UNION ALL
+    SELECT
+        snapshot_accounts.pubkey,
+        snapshot_accounts.owner,
+        snapshot_accounts.lamports,
+        snapshot_accounts.slot,
+        snapshot_accounts.data,
+        snapshot_accounts.token_mint
+    FROM snapshot_accounts
+    WHERE
+        snapshot_accounts.token_mint = $1
+        AND snapshot_accounts.slot <= $2
+),
+
+latest_per_pubkey AS (
+    SELECT DISTINCT ON (pubkey)
+        pubkey,
+        owner,
+        lamports,
+        data
+    FROM all_versions
+    ORDER BY pubkey, slot DESC
+)
+
+SELECT
+    pubkey,
+    SUBSTRING(data FROM 65 FOR 8) AS amount   -- raw LE bytes; handler does from_le_bytes
+FROM latest_per_pubkey
+WHERE lamports > 0
+  -- amount lives at bytes 64..71; require enough bytes so the get_byte() sort below
+  -- can never read past the end (real token accounts are >= 82 bytes anyway).
+  AND octet_length(data) >= 72
+  AND (owner = '\x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9'::bytea      -- Tokenkeg  -- noqa: LT05
+       OR owner = '\x06ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc'::bytea)  -- Token-2022  -- noqa: LT05
+-- Sort by balance: a little-endian u64 at bytes 64..71 reconstructed as numeric.
+-- Keep it numeric, not ::bigint (signed 64-bit, overflows above 2^63).
+ORDER BY (
+      get_byte(data,64)::numeric
+    + get_byte(data,65)::numeric * 256
+    + get_byte(data,66)::numeric * 65536
+    + get_byte(data,67)::numeric * 16777216
+    + get_byte(data,68)::numeric * 4294967296
+    + get_byte(data,69)::numeric * 1099511627776
+    + get_byte(data,70)::numeric * 281474976710656
+    + get_byte(data,71)::numeric * 72057594037927936
+) DESC, pubkey
+LIMIT 20;

--- a/crates/api/src/db/getTokenLargestAccounts.sql
+++ b/crates/api/src/db/getTokenLargestAccounts.sql
@@ -60,5 +60,5 @@ ORDER BY (
     + get_byte(data,69)::numeric * 1099511627776
     + get_byte(data,70)::numeric * 281474976710656
     + get_byte(data,71)::numeric * 72057594037927936
-) DESC, pubkey
+) DESC, pubkey DESC
 LIMIT 20;

--- a/crates/api/src/http/rpc.rs
+++ b/crates/api/src/http/rpc.rs
@@ -471,6 +471,46 @@ async fn process_single_request(
 
             json_response
         }
+        "getTokenLargestAccounts" => {
+            let start_time = Instant::now();
+
+            let pubkey: String = match extract_param(&rpc_request.params, 0) {
+                Ok(p) => p,
+                Err(e) => return make_error_response(id, -32602, e),
+            };
+            let commitment: Option<CommitmentConfig> =
+                extract_param(&rpc_request.params, 1).ok().flatten();
+
+            let result = methods::get_token_largest_accounts::get_token_largest_accounts(
+                state, pubkey, commitment,
+            )
+            .await;
+
+            let status_label = if result.is_ok() {
+                "success"
+            } else {
+                tracing::error!(
+                    target: "api_request_errors_count",
+                    "getTokenLargestAccounts error: {:?}",
+                    result.as_ref().unwrap_err()
+                );
+                "error"
+            };
+            metrics::CLOUDBREAK_API_REQUESTS_TOTAL
+                .with_label_values(&["getTokenLargestAccounts", status_label])
+                .inc();
+
+            let json_response = json_serialize_response(id, result).await;
+
+            metrics::CLOUDBREAK_API_REQUEST_DURATION_MS
+                .with_label_values(&[
+                    "getTokenLargestAccounts",
+                    metrics::bytes_bucket(json_response.len() as u64),
+                ])
+                .observe(start_time.elapsed().as_millis() as f64);
+
+            json_response
+        }
         "getTokenAccountsByOwner" => {
             let owner: String = match extract_param(&rpc_request.params, 0) {
                 Ok(o) => o,

--- a/crates/api/src/methods/get_token_largest_accounts.rs
+++ b/crates/api/src/methods/get_token_largest_accounts.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+use cloudbreak_entity::slots;
+use sea_orm::EntityTrait;
+use sea_orm::sqlx::Row;
+use sea_orm::sqlx::{self};
+use solana_account_decoder::parse_token::token_amount_to_ui_amount_v3;
+use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
+use solana_pubkey::Pubkey;
+use solana_rpc_client_api::response::{
+    Response as RpcResponse, RpcResponseContext, RpcTokenAccountBalance,
+};
+use tokio::time::timeout;
+use tracing::Instrument;
+
+use crate::error::RpcError;
+use crate::http::CloudbreakRpcState;
+use crate::methods::token::parse_additional_mint_data;
+use crate::methods::{is_token_program, resolve_commitment};
+use crate::{db_query, metrics};
+
+#[tracing::instrument(name = "get_token_largest_accounts_rpc", skip_all, fields(pubkey = %mint))]
+pub async fn get_token_largest_accounts(
+    state: &CloudbreakRpcState,
+    mint: String,
+    commitment: Option<CommitmentConfig>,
+) -> Result<RpcResponse<Vec<RpcTokenAccountBalance>>, RpcError> {
+    let _guard = metrics::InFlightRequestGuard::new("getTokenLargestAccounts");
+
+    let pubkey: Pubkey = mint
+        .parse()
+        .map_err(|_| RpcError::PubkeyValidationError(mint.clone()))?;
+
+    let commitment = commitment
+        .map(|commitment_config| {
+            resolve_commitment(commitment_config.commitment, state.processed_commitment)
+        })
+        .transpose()?
+        .unwrap_or(CommitmentLevel::Finalized);
+
+    let (latest_slot, block_time): (u64, i64) = match &state.slot_syncronizer_data {
+        Some(data) => {
+            let data = data.read().expect("Failed to read slot syncronizer data");
+            (
+                data.get_slot_for_commitment(commitment),
+                data.get_block_time_for_commitment(commitment),
+            )
+        }
+        None => {
+            let slot_model = slots::Entity::find_by_id(commitment as i32)
+                .one(&state.database)
+                .instrument(tracing::info_span!("slot_db"))
+                .await?;
+
+            let model = slot_model.ok_or(RpcError::InternalError)?;
+            (model.slot as u64, model.block_time)
+        }
+    };
+
+    let mint_sql = include_str!("../db/getAccountInfo.sql");
+    let mint_hex = format!("'\\x{}'::bytea", hex::encode(pubkey.as_ref()));
+    let mint_sql = mint_sql.replace("$1", &mint_hex);
+    let mint_sql = mint_sql.replace("$2", &latest_slot.to_string());
+    let mint_sql = db_query::add_trace_traceparent_to_query(&mint_sql);
+
+    tracing::debug!(target: "get_token_mint_sql", "## sql: {}", mint_sql);
+
+    let pool = state.database.get_postgres_connection_pool();
+    let mint_rows = timeout(state.queries_timeout, async {
+        let span = tracing::info_span!("get_token_mint_db");
+        sqlx::raw_sql(&mint_sql)
+            .fetch_all(pool)
+            .instrument(span)
+            .await
+    })
+    .await
+    .map_err(|_elapsed| {
+        tracing::error!("getTokenLargestAccounts mint lookup timed out");
+        RpcError::InternalError
+    })?
+    .map_err(|e| {
+        tracing::error!("Database query error: {}", e);
+        RpcError::InternalError
+    })?;
+
+    let Some(mint_row) = mint_rows.first() else {
+        return Err(RpcError::AccountNotFound {
+            pubkey: pubkey.to_string(),
+        });
+    };
+    let owner_bytes: Vec<u8> = mint_row.get("owner");
+    let owner = Pubkey::try_from(owner_bytes.as_slice()).map_err(|_| RpcError::InternalError)?;
+    if !state.indexer_filter.is_program_selected(&owner) {
+        return Err(RpcError::AccountOwnerExcluded {
+            pubkey: pubkey.to_string(),
+            owner: owner.to_string(),
+        });
+    }
+    if !is_token_program(&owner) {
+        return Err(RpcError::NotATokenAccount {
+            pubkey: pubkey.to_string(),
+        });
+    }
+    let data: Vec<u8> = mint_row.get("data");
+    let additional_mint_data = parse_additional_mint_data(&pubkey, &data, block_time);
+    let additional_data = additional_mint_data
+        .as_ref()
+        .and_then(|d| d.spl_token_additional_data.as_ref())
+        .ok_or_else(|| RpcError::MintDataNotFound {
+            mint: pubkey.to_string(),
+        })?;
+
+    let sql_template = include_str!("../db/getTokenLargestAccounts.sql");
+    let sql = sql_template.replace("$1", &mint_hex);
+    let sql = sql.replace("$2", &latest_slot.to_string());
+    let sql = db_query::add_trace_traceparent_to_query(&sql);
+
+    tracing::debug!(target: "get_token_largest_accounts_sql", "## sql: {}", sql);
+
+    let holder_rows = timeout(state.queries_timeout, async {
+        let span = tracing::info_span!("get_token_largest_accounts_db");
+        sqlx::raw_sql(&sql).fetch_all(pool).instrument(span).await
+    })
+    .await
+    .map_err(|_elapsed| {
+        tracing::error!("getTokenLargestAccounts holder query timed out");
+        RpcError::InternalError
+    })?
+    .map_err(|e| {
+        tracing::error!("Database query error: {}", e);
+        RpcError::InternalError
+    })?;
+
+    let mut value = Vec::with_capacity(holder_rows.len());
+    for row in &holder_rows {
+        let address_bytes: Vec<u8> = row.get("pubkey");
+        let address = Pubkey::try_from(address_bytes.as_slice())
+            .map_err(|_| RpcError::InternalError)?
+            .to_string();
+
+        let amount_bytes: Vec<u8> = row.get("amount");
+        let amount_array: [u8; 8] = amount_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| RpcError::InternalError)?;
+        let amount = u64::from_le_bytes(amount_array);
+
+        value.push(RpcTokenAccountBalance {
+            address,
+            amount: token_amount_to_ui_amount_v3(amount, additional_data),
+        });
+    }
+
+    Ok(RpcResponse {
+        context: RpcResponseContext {
+            slot: latest_slot,
+            api_version: None,
+        },
+        value,
+    })
+}

--- a/crates/api/src/methods/mod.rs
+++ b/crates/api/src/methods/mod.rs
@@ -15,6 +15,7 @@ pub mod get_account_info;
 pub mod get_balance;
 pub mod get_multiple_accounts;
 pub mod get_token_account_balance;
+pub mod get_token_largest_accounts;
 pub mod get_token_supply;
 pub mod mint;
 pub mod mint_accounts;


### PR DESCRIPTION
Closes #20.

## What this adds

getTokenLargestAccounts, the companion to the by-mint reads that was still missing. Give it a mint, get back the 20 biggest token accounts for that mint, sorted high to low, each as `{ address, amount }` where amount is a `UiTokenAmount`. Matches Agave's shape.

## How it works

Two steps.

First, resolve the mint. Parse the pubkey, resolve the slot and block time for the commitment, then look the mint up by pubkey with `getAccountInfo.sql` and run the usual guards: not in the DB is AccountNotFound, owner not in the index filter is AccountOwnerExcluded, owner not a token program is an invalid-param error. This step also gives me the decimals, through the same `parse_additional_mint_data` the balance handler uses, so Token-2022 mints with interest-bearing or scaled-ui-amount extensions go through the same path they do there.

Second, pull the holders. A new `getTokenLargestAccounts.sql` selects the mint's token accounts off the `token_mint` column (and its `idx_accounts_token_mint` index), keeps the latest version per pubkey with `DISTINCT ON`, filters to live token-program accounts (lamports > 0, owner is Tokenkeg or Token-2022), sorts by balance descending and takes 20. Each row's amount is the same little-endian `u64` at data bytes 64..72 that getTokenAccountBalance reads. I map those to `RpcTokenAccountBalance` and return `RpcResponse<Vec<RpcTokenAccountBalance>>`. A mint with no holders comes back as an empty list, not an error.

## Sorting by balance

The balance isn't a column, it's a little-endian `u64` inside the account data blob, so there's nothing to plainly `ORDER BY`. I rebuild it in the `ORDER BY` from the 8 bytes (`get_byte(data, 64..71)` times 256^0..256^7) as a Postgres `numeric`. It has to be `numeric`, not `bigint`: `bigint` is signed 64-bit and a token amount can go past 2^63 and overflow it. There's a comment in the SQL saying so, so it doesn't get "simplified" to `bigint` later.

I did the top 20 in SQL instead of pulling every holder into the handler and sorting in Rust, so Postgres hands back 20 rows rather than potentially millions for a big mint.

## On big mints

The SQL still has to scan the mint's whole holder set to sort it. The index covers the `token_mint =` match, but nothing indexes the amount, so the sort runs over every matched row. For a mint with a huge number of holders that can be slow or hit the query timeout. Agave has the same shape here (it pulls the holder set from a secondary index, then sorts them all and takes the top 20 in memory, and operators routinely exclude the biggest mints from that index), so it isn't specific to cloudbreak. Making it cheap for huge mints would need a new amount column and index, which I kept out (the issue was explicit about no new indexes). The query stays bounded by the existing per-query timeout and only ever returns 20 rows.

## How I tested it

Ran it against a running API on seeded data:

- The top 20 come back in the right order, including amounts above 2^63 (the case a `bigint` sort gets wrong), with correct amount, decimals, uiAmount and uiAmountString.
- A pubkey not in the DB returns AccountNotFound.
- A pubkey that's a token account rather than a mint returns the "could not find mint" invalid-param error.
- A malformed pubkey returns the pubkey validation error.
- Closed accounts (lamports 0) and non-token-program owners are left out, and an older version of a holder is shadowed by its newest one.

No automated tests in this PR. The crate doesn't unit-test the RPC handlers; these methods get checked through the integration_tests compare harness, which diffs cloudbreak against a live cluster. That comparison only means anything when cloudbreak is populated with real ingested data and pointed at a cluster, so the getTokenLargestAccounts arm belongs in its own PR. The harness already calls cluster getTokenLargestAccounts as an oracle for getTokenAccountsByMint, so adding the arm is small once it can run against real data.
