### PR TITLE
fix: indexer crash-loops on "relation already exists" during self-healing

### DIFF
--- a/crates/snapshot/src/db/create_accounts_to_delete_table.sql
+++ b/crates/snapshot/src/db/create_accounts_to_delete_table.sql
@@ -7,6 +7,8 @@
 -- with the accounts to delete (which are the accounts that have multiple 
 -- versions in the temp_snapshot_account_versions table, and this table will
 -- contain all the older versions of the account)
+DROP TABLE IF EXISTS accounts_to_delete;
+
 CREATE UNLOGGED TABLE accounts_to_delete AS
 SELECT
     owner,


### PR DESCRIPTION
**fix: indexer crash-loops on "relation already exists" during self-healing**

`create_accounts_to_delete_table.sql` ran a plain `CREATE UNLOGGED TABLE accounts_to_delete AS SELECT ...` with no preceding drop. On the first snapshot run the table is created and never cleaned up within the process. When self-healing triggers a second snapshot run, the same `CREATE` fires again → `relation "accounts_to_delete" already exists` → panic → process exits → full re-bootstrap → next gap → same panic. Unbreakable crash loop.

Fixed by prepending `DROP TABLE IF EXISTS accounts_to_delete` to the SQL, mirroring the existing cleanup pattern used by `temp_closed_accounts`.

Closes #18 