### PR TITLE
`metrics` Add bandwidth metrics to API and allow configurable Gbit/s limit to integration tests

### DIFF
--- a/crates/api/src/http/server.rs
+++ b/crates/api/src/http/server.rs
@@ -33,18 +33,22 @@ use crate::http::CloudbreakRpcState;
 use crate::http::operational_endpoints;
 use crate::http::rpc;
 use crate::metrics;
+use crate::modules::bandwidth;
 
 pub struct HttpServer {
     state: Arc<CloudbreakRpcState>,
     subscription_id_key: String,
-    client_ip_key: String,
+    /// Header carrying the client IP for the (optional) per-client-IP bandwidth
+    /// metrics. `None` means "not configured" — all bandwidth is attributed to
+    /// a single placeholder label rather than reading any request header.
+    client_ip_key: Option<String>,
 }
 
 impl HttpServer {
     pub fn new(
         state: CloudbreakRpcState,
         subscription_id_key: String,
-        client_ip_key: String,
+        client_ip_key: Option<String>,
     ) -> Self {
         Self {
             state: Arc::new(state),
@@ -62,7 +66,7 @@ impl HttpServer {
         let client_ip_key = self.client_ip_key;
 
         loop {
-            let (stream, remote_addr) = listener.accept().await?;
+            let (stream, _remote_addr) = listener.accept().await?;
 
             let io = TokioIo::new(stream);
             let state = state.clone();
@@ -83,14 +87,8 @@ impl HttpServer {
                     *requests_in_connection.lock().unwrap() += 1;
 
                     async move {
-                        handle_request(
-                            req,
-                            state,
-                            subscription_id_key.clone(),
-                            client_ip_key.clone(),
-                            remote_addr,
-                        )
-                        .await
+                        handle_request(req, state, subscription_id_key.clone(), client_ip_key)
+                            .await
                     }
                 });
 
@@ -127,21 +125,11 @@ async fn handle_request(
     req: Request<Incoming>,
     state: Arc<CloudbreakRpcState>,
     subscription_id_key: String,
-    client_ip_key: String,
-    remote_addr: SocketAddr,
+    client_ip_key: Option<String>,
 ) -> Result<Response<UnsyncBoxBody<Bytes, Infallible>>, Infallible> {
     let request_start = Instant::now();
     let inflight_guard = metrics::InFlightRequestGuard::new("http");
     let request_timeout = state.request_timeout;
-
-    tracing::debug!(
-        target: "api_request_headers",
-        method = %req.method(),
-        uri = %req.uri(),
-        remote_addr = %remote_addr,
-        headers = ?req.headers(),
-        "incoming API request"
-    );
 
     // Extract subscription ID from headers
     let subscription_id = req
@@ -151,14 +139,20 @@ async fn handle_request(
         .unwrap_or("unknown-subscription-id")
         .to_string();
 
-    // Extract the client IP for per-client-IP bandwidth metrics. Prefer the configured
-    // header, fall back to the socket peer address when the header is absent.
-    let client_ip = req
-        .headers()
-        .get(&client_ip_key)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| remote_addr.ip().to_string());
+    // Resolve the per-client-IP bandwidth handle once per request; the transport
+    // path is then a lock-free atomic add per frame. `None` when the module is
+    // disabled. When `client-ip-key` is unset — or the header is absent — bytes
+    // fold into a single placeholder label rather than reading any
+    // client-settable/PII header value.
+    let bw = if bandwidth::is_enabled() {
+        let label = client_ip_key
+            .as_deref()
+            .and_then(|key| req.headers().get(key).and_then(|v| v.to_str().ok()))
+            .unwrap_or(bandwidth::UNCONFIGURED_CLIENT_IP);
+        bandwidth::handle_for(label)
+    } else {
+        None
+    };
 
     let handler_response = match (req.method(), req.uri().path()) {
         (&Method::POST, "/") => rpc::handle_rpc_request(req, state, &subscription_id).await,
@@ -193,7 +187,7 @@ async fn handle_request(
         _inflight_guard: inflight_guard,
         deadline: Box::pin(tokio::time::sleep(request_timeout)),
         timed_out: false,
-        client_ip,
+        bw,
     };
 
     let body = BodyExt::boxed_unsync(tracked);
@@ -250,8 +244,9 @@ struct TrackedBody<B> {
     /// does not continue polling the body.
     deadline: Pin<Box<Sleep>>,
     timed_out: bool,
-    /// Client IP for per-client-IP bandwidth metrics.
-    client_ip: String,
+    /// Per-client-IP bandwidth accumulator handle, resolved once per request.
+    /// `None` when the bandwidth module is disabled.
+    bw: Option<bandwidth::BandwidthHandle>,
 }
 
 impl<B> Body for TrackedBody<B>
@@ -292,8 +287,10 @@ where
                 if let Some(data) = frame.data_ref() {
                     let n = data.len() as u64;
                     this.bytes_count += n;
-                    // Attribute bytes to the 100ms window they are transmitted in,
-                    crate::modules::bandwidth::record(&this.client_ip, n);
+                    // Attribute bytes to the current 1s window (lock-free add).
+                    if let Some(bw) = &this.bw {
+                        bw.add(n);
+                    }
                 }
                 Poll::Ready(Some(Ok(frame)))
             }

--- a/crates/api/src/http/server.rs
+++ b/crates/api/src/http/server.rs
@@ -37,13 +37,19 @@ use crate::metrics;
 pub struct HttpServer {
     state: Arc<CloudbreakRpcState>,
     subscription_id_key: String,
+    client_ip_key: String,
 }
 
 impl HttpServer {
-    pub fn new(state: CloudbreakRpcState, subscription_id_key: String) -> Self {
+    pub fn new(
+        state: CloudbreakRpcState,
+        subscription_id_key: String,
+        client_ip_key: String,
+    ) -> Self {
         Self {
             state: Arc::new(state),
             subscription_id_key,
+            client_ip_key,
         }
     }
 
@@ -53,6 +59,7 @@ impl HttpServer {
 
         let state = self.state;
         let subscription_id_key = self.subscription_id_key;
+        let client_ip_key = self.client_ip_key;
 
         loop {
             let (stream, remote_addr) = listener.accept().await?;
@@ -60,6 +67,7 @@ impl HttpServer {
             let io = TokioIo::new(stream);
             let state = state.clone();
             let subscription_id_key = subscription_id_key.clone();
+            let client_ip_key = client_ip_key.clone();
 
             tokio::spawn(async move {
                 let start_time = Instant::now();
@@ -70,11 +78,19 @@ impl HttpServer {
                 let service = service_fn(move |req: Request<Incoming>| {
                     let state = state.clone();
                     let subscription_id_key = subscription_id_key.clone();
+                    let client_ip_key = client_ip_key.clone();
 
                     *requests_in_connection.lock().unwrap() += 1;
 
                     async move {
-                        handle_request(req, state, subscription_id_key.clone(), remote_addr).await
+                        handle_request(
+                            req,
+                            state,
+                            subscription_id_key.clone(),
+                            client_ip_key.clone(),
+                            remote_addr,
+                        )
+                        .await
                     }
                 });
 
@@ -111,11 +127,21 @@ async fn handle_request(
     req: Request<Incoming>,
     state: Arc<CloudbreakRpcState>,
     subscription_id_key: String,
-    _remote_addr: SocketAddr,
+    client_ip_key: String,
+    remote_addr: SocketAddr,
 ) -> Result<Response<UnsyncBoxBody<Bytes, Infallible>>, Infallible> {
     let request_start = Instant::now();
     let inflight_guard = metrics::InFlightRequestGuard::new("http");
     let request_timeout = state.request_timeout;
+
+    tracing::debug!(
+        target: "api_request_headers",
+        method = %req.method(),
+        uri = %req.uri(),
+        remote_addr = %remote_addr,
+        headers = ?req.headers(),
+        "incoming API request"
+    );
 
     // Extract subscription ID from headers
     let subscription_id = req
@@ -124,6 +150,15 @@ async fn handle_request(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("unknown-subscription-id")
         .to_string();
+
+    // Extract the client IP for per-client-IP bandwidth metrics. Prefer the configured
+    // header, fall back to the socket peer address when the header is absent.
+    let client_ip = req
+        .headers()
+        .get(&client_ip_key)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| remote_addr.ip().to_string());
 
     let handler_response = match (req.method(), req.uri().path()) {
         (&Method::POST, "/") => rpc::handle_rpc_request(req, state, &subscription_id).await,
@@ -158,6 +193,7 @@ async fn handle_request(
         _inflight_guard: inflight_guard,
         deadline: Box::pin(tokio::time::sleep(request_timeout)),
         timed_out: false,
+        client_ip,
     };
 
     let body = BodyExt::boxed_unsync(tracked);
@@ -214,6 +250,8 @@ struct TrackedBody<B> {
     /// does not continue polling the body.
     deadline: Pin<Box<Sleep>>,
     timed_out: bool,
+    /// Client IP for per-client-IP bandwidth metrics.
+    client_ip: String,
 }
 
 impl<B> Body for TrackedBody<B>
@@ -252,7 +290,10 @@ where
         match inner.poll_frame(cx) {
             Poll::Ready(Some(Ok(frame))) => {
                 if let Some(data) = frame.data_ref() {
-                    this.bytes_count += data.len() as u64;
+                    let n = data.len() as u64;
+                    this.bytes_count += n;
+                    // Attribute bytes to the 100ms window they are transmitted in,
+                    crate::modules::bandwidth::record(&this.client_ip, n);
                 }
                 Poll::Ready(Some(Ok(frame)))
             }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -63,6 +63,7 @@ pub async fn run(config: &str) -> cloudbreak_core::Result<()> {
     };
 
     let subscription_id_key = config.metrics.subscription_id_key.clone();
+    let client_ip_key = config.metrics.client_ip_key.clone();
 
     let (mut slot_syncronizer_handle, slot_syncronizer_data) =
         match slot_syncronizer::start_slot_syncronizer(database.clone(), &config) {
@@ -141,7 +142,7 @@ pub async fn run(config: &str) -> cloudbreak_core::Result<()> {
 
     info!("Server is starting...");
 
-    let server = http::server::HttpServer::new(state, subscription_id_key);
+    let server = http::server::HttpServer::new(state, subscription_id_key, client_ip_key);
 
     tokio::select! {
         result = server.run(config.server_addr()) => { match result {

--- a/crates/api/src/metrics.rs
+++ b/crates/api/src/metrics.rs
@@ -191,7 +191,6 @@ fn refresh_db_pool_metrics(database: &DatabaseConnection) {
 
 pub fn metrics_handler(database: &DatabaseConnection) -> Result<HttpHandlerResponse, Infallible> {
     refresh_db_pool_metrics(database);
-    crate::modules::bandwidth::refresh_gauges();
 
     let metrics = TextEncoder::new()
         .encode_to_string(&METRICS_REGISTRY.gather())

--- a/crates/api/src/metrics.rs
+++ b/crates/api/src/metrics.rs
@@ -231,8 +231,12 @@ pub fn setup_metrics(config: &ApiConfig) -> anyhow::Result<()> {
         register!(CLOUDBREAK_GPA_CACHE_EVICTED_BYTES_TOTAL);
 
         // Per-client-IP egress bandwidth (peak gauge + throughput histogram).
-        // Registers its collectors and starts the 100ms sampler task.
-        crate::modules::bandwidth::register(&METRICS_REGISTRY);
+        // Optional, off by default: registers its collectors and starts the 1s
+        // sampler task only when enabled in config.
+        crate::modules::bandwidth::register(
+            &METRICS_REGISTRY,
+            config.metrics.client_ip_bandwidth_enabled,
+        );
     });
 
     // Set the max connections as a reference metric at startup

--- a/crates/api/src/metrics.rs
+++ b/crates/api/src/metrics.rs
@@ -191,6 +191,7 @@ fn refresh_db_pool_metrics(database: &DatabaseConnection) {
 
 pub fn metrics_handler(database: &DatabaseConnection) -> Result<HttpHandlerResponse, Infallible> {
     refresh_db_pool_metrics(database);
+    crate::modules::bandwidth::refresh_gauges();
 
     let metrics = TextEncoder::new()
         .encode_to_string(&METRICS_REGISTRY.gather())
@@ -229,6 +230,10 @@ pub fn setup_metrics(config: &ApiConfig) -> anyhow::Result<()> {
         register!(CLOUDBREAK_GPA_CACHE_MAX_BYTES);
         register!(CLOUDBREAK_GPA_CACHE_EVICTIONS_TOTAL);
         register!(CLOUDBREAK_GPA_CACHE_EVICTED_BYTES_TOTAL);
+
+        // Per-client-IP egress bandwidth (peak gauge + throughput histogram).
+        // Registers its collectors and starts the 100ms sampler task.
+        crate::modules::bandwidth::register(&METRICS_REGISTRY);
     });
 
     // Set the max connections as a reference metric at startup

--- a/crates/api/src/modules/bandwidth.rs
+++ b/crates/api/src/modules/bandwidth.rs
@@ -5,24 +5,28 @@
 
 //! Per-client-IP egress bandwidth tracking.
 //!
-//! Mechanism (one 100 ms slotting engine feeding two views):
+//! Mechanism (one 1 s slotting engine feeding two views):
 //!  - Every response frame's byte length is attributed, as it is written to the
-//!    wire, to the current 100 ms window for its client IP via [`record`]. This
-//!    is a single cheap atomic add on the hot path.
-//!  - A background sampler ([`spawn_sampler`]) rotates the window every 100 ms:
-//!    it snapshots+resets each client's accumulator, updates a per-scrape
-//!    running max, and observes the window throughput into a histogram.
-//!  - **A — gauge** `cloudbreak_api_client_ip_peak_bytes_per_second`: the peak
-//!    100 ms-window throughput since the last scrape. Refreshed + reset at
-//!    scrape time by [`refresh_gauges`].
+//!    wire, to the current 1 s window for its client IP via [`record`]. This is
+//!    a single cheap atomic add on the hot path.
+//!  - A background sampler ([`spawn_sampler`]) closes the window every second:
+//!    it snapshots+resets each client's accumulator (yielding a directly
+//!    measured bytes/sec), feeds it into both views, and there is no ×10
+//!    extrapolation.
+//!  - **A — gauge** `cloudbreak_api_client_ip_peak_bytes_per_second`: the max
+//!    1 s-window throughput over the trailing [`WINDOW_SECS`] seconds. Set by
+//!    the sampler once per second and simply read at scrape time — never reset
+//!    on read, so any number of `/metrics` consumers is harmless. Idle clients
+//!    decay to 0 once their peak ages out of the window.
 //!  - **B — histogram** `cloudbreak_api_client_ip_throughput_bytes_per_second`:
-//!    distribution of 100 ms-window throughput samples.
+//!    distribution of 1 s-window throughput samples (active windows only).
 //!
 //! Cardinality is capped at [`MAX_CLIENT_IPS`] distinct IPs; further IPs are
 //! bucketed under [`OTHER_LABEL`].
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -30,30 +34,60 @@ use std::time::Duration;
 use lazy_static::lazy_static;
 use prometheus::{GaugeVec, HistogramOpts, HistogramVec, Opts, Registry};
 
-/// Length of each throughput window. The precision knob: smaller catches
-/// shorter bursts. `bytes_in_slot * SLOT_HZ = bytes/sec`.
-const SLOT_MS: u64 = 100;
-const SLOT_HZ: f64 = 1000.0 / SLOT_MS as f64;
+/// Length of each throughput window. Bytes accumulated in one slot is already a
+/// bytes/sec rate, so no extrapolation is applied to either view.
+const SLOT_MS: u64 = 1000;
+
+/// Trailing window (in 1 s slots) over which the peak gauge reports its max.
+/// "Max seen in the last minute": as long as the Prometheus scrape interval is
+/// `<= WINDOW_SECS`, every 1 s window's peak stays published long enough to be
+/// scraped at least once, so no spike is lost.
+const WINDOW_SECS: usize = 60;
 
 /// Max distinct client-IP label values before overflow is bucketed under
 /// [`OTHER_LABEL`], keeping series count bounded.
 const MAX_CLIENT_IPS: usize = 100;
 const OTHER_LABEL: &str = "overflowed-ips";
 
-/// Per-client accumulator. `current` is the still-open window's byte total;
-/// `running_max` is the largest closed-window byte total since the last gauge
-/// refresh (drives the peak gauge).
+/// Per-client accumulator. `current` is the still-open 1 s window's byte total
+/// (touched on the hot path). `window` is a ring of the last [`WINDOW_SECS`]
+/// closed 1 s totals, touched only by the single sampler task; its max drives
+/// the peak gauge.
 struct ClientBw {
     current: AtomicU64,
-    running_max: AtomicU64,
+    window: Mutex<PeakWindow>,
 }
 
 impl ClientBw {
     fn new() -> Self {
         Self {
             current: AtomicU64::new(0),
-            running_max: AtomicU64::new(0),
+            window: Mutex::new(PeakWindow::new()),
         }
+    }
+}
+
+/// Fixed-size ring of the last [`WINDOW_SECS`] closed 1 s byte totals. Only the
+/// sampler task accesses it, so the mutex is effectively uncontended.
+struct PeakWindow {
+    slots: [u64; WINDOW_SECS],
+    idx: usize,
+}
+
+impl PeakWindow {
+    fn new() -> Self {
+        Self {
+            slots: [0; WINDOW_SECS],
+            idx: 0,
+        }
+    }
+
+    /// Push the newest closed-window total (which may be 0 for an idle second so
+    /// that stale peaks age out) and return the max over the trailing window.
+    fn push_and_max(&mut self, closed: u64) -> u64 {
+        self.slots[self.idx] = closed;
+        self.idx = (self.idx + 1) % WINDOW_SECS;
+        self.slots.iter().copied().max().unwrap_or(0)
     }
 }
 
@@ -78,23 +112,23 @@ fn throughput_buckets() -> Vec<f64> {
 lazy_static! {
     static ref STATE: RwLock<HashMap<String, Arc<ClientBw>>> = RwLock::new(HashMap::new());
 
-    /// View A: peak per-client-IP egress throughput (bytes/sec) over any 100 ms
-    /// window since the last scrape.
+    /// View A: peak per-client-IP egress throughput (bytes/sec) over any 1 s
+    /// window in the trailing `WINDOW_SECS`.
     pub static ref CLIENT_IP_PEAK_BYTES_PER_SEC: GaugeVec = GaugeVec::new(
         Opts::new(
             "cloudbreak_api_client_ip_peak_bytes_per_second",
-            "Peak per-client-IP egress throughput in bytes/sec over any 100ms window since the last scrape."
+            "Peak per-client-IP egress throughput in bytes/sec over any 1s window in the trailing 60s."
         ),
         &["client_ip"],
     )
     .unwrap();
 
     /// View B: distribution of per-client-IP egress throughput (bytes/sec),
-    /// sampled over 100 ms windows.
+    /// sampled over 1 s windows.
     pub static ref CLIENT_IP_THROUGHPUT_BYTES_PER_SEC: HistogramVec = HistogramVec::new(
         HistogramOpts::new(
             "cloudbreak_api_client_ip_throughput_bytes_per_second",
-            "Distribution of per-client-IP egress throughput in bytes/sec, sampled over 100ms windows."
+            "Distribution of per-client-IP egress throughput in bytes/sec, sampled over 1s windows."
         )
         .buckets(throughput_buckets()),
         &["client_ip"],
@@ -116,8 +150,8 @@ pub fn register(registry: &Registry) {
 }
 
 /// The single hot-path call: attribute `bytes` of egress to `client_ip`'s
-/// currently-open 100 ms window. Cheap: a read-lock + atomic add on the fast
-/// path; a write-lock only when first seeing an IP (or routing overflow to
+/// currently-open 1 s window. Cheap: a read-lock + atomic add on the fast path;
+/// a write-lock only when first seeing an IP (or routing overflow to
 /// [`OTHER_LABEL`]).
 pub fn record(client_ip: &str, bytes: u64) {
     if bytes == 0 {
@@ -149,9 +183,10 @@ pub fn record(client_ip: &str, bytes: u64) {
     client.current.fetch_add(bytes, Ordering::Relaxed);
 }
 
-/// Close the current 100 ms window for every tracked client: snapshot+reset the
-/// accumulator, fold it into the per-scrape running max (A), and record the
-/// window's throughput into the histogram (B).
+/// Close the current 1 s window for every tracked client: snapshot+reset the
+/// accumulator, fold the closed total into the trailing-window peak and publish
+/// it to the gauge (A), and — for active windows — record the throughput into
+/// the histogram (B).
 fn sample_once() {
     // Snapshot the Arcs under a short read lock, then work lock-free.
     let clients: Vec<(String, Arc<ClientBw>)> = {
@@ -161,18 +196,25 @@ fn sample_once() {
 
     for (ip, client) in clients {
         let closed = client.current.swap(0, Ordering::Relaxed);
-        if closed == 0 {
-            continue;
+
+        // View B: only observe active windows so idle seconds don't drag the
+        // distribution toward 0.
+        if closed > 0 {
+            CLIENT_IP_THROUGHPUT_BYTES_PER_SEC
+                .with_label_values(&[&ip])
+                .observe(closed as f64);
         }
-        client.running_max.fetch_max(closed, Ordering::Relaxed);
-        let bytes_per_sec = closed as f64 * SLOT_HZ;
-        CLIENT_IP_THROUGHPUT_BYTES_PER_SEC
+
+        // View A: push the closed total (including 0 for idle seconds, so stale
+        // peaks age out of the trailing window) and publish the rolling max.
+        let peak = client.window.lock().unwrap().push_and_max(closed);
+        CLIENT_IP_PEAK_BYTES_PER_SEC
             .with_label_values(&[&ip])
-            .observe(bytes_per_sec);
+            .set(peak as f64);
     }
 }
 
-/// Spawn the 100 ms sampler task. Safe to call once from `setup_metrics`.
+/// Spawn the 1 s sampler task. Safe to call once from `setup_metrics`.
 pub fn spawn_sampler() {
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(Duration::from_millis(SLOT_MS));
@@ -182,20 +224,4 @@ pub fn spawn_sampler() {
             sample_once();
         }
     });
-}
-
-/// Publish the peak gauge (A) at scrape time and reset the per-scrape running
-/// max. Called from the `/metrics` handler.
-pub fn refresh_gauges() {
-    let clients: Vec<(String, Arc<ClientBw>)> = {
-        let map = STATE.read().unwrap();
-        map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
-    };
-
-    for (ip, client) in clients {
-        let peak_slot_bytes = client.running_max.swap(0, Ordering::Relaxed);
-        CLIENT_IP_PEAK_BYTES_PER_SEC
-            .with_label_values(&[&ip])
-            .set(peak_slot_bytes as f64 * SLOT_HZ);
-    }
 }

--- a/crates/api/src/modules/bandwidth.rs
+++ b/crates/api/src/modules/bandwidth.rs
@@ -5,10 +5,15 @@
 
 //! Per-client-IP egress bandwidth tracking.
 //!
+//! Optional module, **off by default** — enabled via
+//! `[metrics].client-ip-bandwidth-enabled`. When disabled, nothing is
+//! registered, no sampler runs, and [`handle_for`] returns `None`, so the
+//! transport path does no work.
+//!
 //! Mechanism (one 1 s slotting engine feeding two views):
-//!  - Every response frame's byte length is attributed, as it is written to the
-//!    wire, to the current 1 s window for its client IP via [`record`]. This is
-//!    a single cheap atomic add on the hot path.
+//!  - Per request the transport layer resolves a [`BandwidthHandle`] once via
+//!    [`handle_for`], then attributes each response frame's byte length to the
+//!    current 1 s window with a single lock-free atomic add ([`BandwidthHandle::add`]).
 //!  - A background sampler ([`spawn_sampler`]) closes the window every second:
 //!    it snapshots+resets each client's accumulator (yielding a directly
 //!    measured bytes/sec), feeds it into both views, and there is no ×10
@@ -28,7 +33,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::RwLock;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use lazy_static::lazy_static;
@@ -48,6 +53,15 @@ const WINDOW_SECS: usize = 60;
 /// [`OTHER_LABEL`], keeping series count bounded.
 const MAX_CLIENT_IPS: usize = 100;
 const OTHER_LABEL: &str = "overflowed-ips";
+
+/// Placeholder client-IP label used when no `client-ip-key` is configured (or a
+/// request lacks the header). All such bytes fold into this single series.
+pub const UNCONFIGURED_CLIENT_IP: &str = "unconfigured";
+
+/// Set true by [`register`] when the module is enabled. Guards [`handle_for`]
+/// and is exposed via [`is_enabled`] so the transport path skips all work when
+/// the module is off.
+static ENABLED: AtomicBool = AtomicBool::new(false);
 
 /// Per-client accumulator. `current` is the still-open 1 s window's byte total
 /// (touched on the hot path). `window` is a ring of the last [`WINDOW_SECS`]
@@ -136,10 +150,15 @@ lazy_static! {
     .unwrap();
 }
 
-/// Register the bandwidth collectors and start the background sampler. Called
-/// once from `setup_metrics` (inside the tokio runtime). Registration and
-/// sampler startup are idempotent-safe to call once.
-pub fn register(registry: &Registry) {
+/// Register the bandwidth collectors and start the background sampler — but
+/// only when `enabled`. When disabled this is a no-op: nothing is registered
+/// and no sampler runs. Must be called once from `setup_metrics` (the `Once`
+/// there is the guard; a second call would panic on re-registration).
+pub fn register(registry: &Registry, enabled: bool) {
+    if !enabled {
+        return;
+    }
+    ENABLED.store(true, Ordering::Relaxed);
     registry
         .register(Box::new(CLIENT_IP_PEAK_BYTES_PER_SEC.clone()))
         .expect("client-ip peak gauge can't be registered");
@@ -149,21 +168,41 @@ pub fn register(registry: &Registry) {
     spawn_sampler();
 }
 
-/// The single hot-path call: attribute `bytes` of egress to `client_ip`'s
-/// currently-open 1 s window. Cheap: a read-lock + atomic add on the fast path;
-/// a write-lock only when first seeing an IP (or routing overflow to
-/// [`OTHER_LABEL`]).
-pub fn record(client_ip: &str, bytes: u64) {
-    if bytes == 0 {
-        return;
+/// Whether the module is enabled (set once at [`register`] time). Lets callers
+/// skip label extraction entirely when the module is off.
+pub fn is_enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+/// A per-request handle to one client's byte accumulator, resolved once by
+/// [`handle_for`]. The transport path then attributes each frame with a single
+/// lock-free atomic add, avoiding a per-frame map lookup + string hash.
+pub struct BandwidthHandle(Arc<ClientBw>);
+
+impl BandwidthHandle {
+    /// Attribute `bytes` of egress to this request's currently-open 1 s window.
+    pub fn add(&self, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+        self.0.current.fetch_add(bytes, Ordering::Relaxed);
+    }
+}
+
+/// Resolve (creating if needed) the accumulator for `client_ip` and return a
+/// handle for the lock-free per-frame path. Returns `None` when the module is
+/// disabled. Takes the write lock only when first seeing an IP (or routing
+/// overflow to [`OTHER_LABEL`] once at capacity); called once per request.
+pub fn handle_for(client_ip: &str) -> Option<BandwidthHandle> {
+    if !is_enabled() {
+        return None;
     }
 
     // Fast path: entry already exists.
     {
         let map = STATE.read().unwrap();
         if let Some(client) = map.get(client_ip) {
-            client.current.fetch_add(bytes, Ordering::Relaxed);
-            return;
+            return Some(BandwidthHandle(client.clone()));
         }
     }
 
@@ -171,16 +210,18 @@ pub fn record(client_ip: &str, bytes: u64) {
     let mut map = STATE.write().unwrap();
     // Re-check under the write lock in case another thread inserted it.
     if let Some(client) = map.get(client_ip) {
-        client.current.fetch_add(bytes, Ordering::Relaxed);
-        return;
+        return Some(BandwidthHandle(client.clone()));
     }
     let key = if map.len() < MAX_CLIENT_IPS {
         client_ip.to_string()
     } else {
         OTHER_LABEL.to_string()
     };
-    let client = map.entry(key).or_insert_with(|| Arc::new(ClientBw::new()));
-    client.current.fetch_add(bytes, Ordering::Relaxed);
+    let client = map
+        .entry(key)
+        .or_insert_with(|| Arc::new(ClientBw::new()))
+        .clone();
+    Some(BandwidthHandle(client))
 }
 
 /// Close the current 1 s window for every tracked client: snapshot+reset the

--- a/crates/api/src/modules/bandwidth.rs
+++ b/crates/api/src/modules/bandwidth.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! Per-client-IP egress bandwidth tracking.
+//!
+//! Mechanism (one 100 ms slotting engine feeding two views):
+//!  - Every response frame's byte length is attributed, as it is written to the
+//!    wire, to the current 100 ms window for its client IP via [`record`]. This
+//!    is a single cheap atomic add on the hot path.
+//!  - A background sampler ([`spawn_sampler`]) rotates the window every 100 ms:
+//!    it snapshots+resets each client's accumulator, updates a per-scrape
+//!    running max, and observes the window throughput into a histogram.
+//!  - **A — gauge** `cloudbreak_api_client_ip_peak_bytes_per_second`: the peak
+//!    100 ms-window throughput since the last scrape. Refreshed + reset at
+//!    scrape time by [`refresh_gauges`].
+//!  - **B — histogram** `cloudbreak_api_client_ip_throughput_bytes_per_second`:
+//!    distribution of 100 ms-window throughput samples.
+//!
+//! Cardinality is capped at [`MAX_CLIENT_IPS`] distinct IPs; further IPs are
+//! bucketed under [`OTHER_LABEL`].
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use lazy_static::lazy_static;
+use prometheus::{GaugeVec, HistogramOpts, HistogramVec, Opts, Registry};
+
+/// Length of each throughput window. The precision knob: smaller catches
+/// shorter bursts. `bytes_in_slot * SLOT_HZ = bytes/sec`.
+const SLOT_MS: u64 = 100;
+const SLOT_HZ: f64 = 1000.0 / SLOT_MS as f64;
+
+/// Max distinct client-IP label values before overflow is bucketed under
+/// [`OTHER_LABEL`], keeping series count bounded.
+const MAX_CLIENT_IPS: usize = 100;
+const OTHER_LABEL: &str = "overflowed-ips";
+
+/// Per-client accumulator. `current` is the still-open window's byte total;
+/// `running_max` is the largest closed-window byte total since the last gauge
+/// refresh (drives the peak gauge).
+struct ClientBw {
+    current: AtomicU64,
+    running_max: AtomicU64,
+}
+
+impl ClientBw {
+    fn new() -> Self {
+        Self {
+            current: AtomicU64::new(0),
+            running_max: AtomicU64::new(0),
+        }
+    }
+}
+
+/// Histogram buckets in **bytes/sec**.
+/// (1 Gbit/s = 0.125 GB/s = 1.25e8 bytes/sec.)
+fn throughput_buckets() -> Vec<f64> {
+    vec![
+        1.25e7,  // 0.1 Gbit/s
+        2.5e8,   // 2
+        5.0e8,   // 4
+        7.5e8,   // 6
+        1.0e9,   // 8
+        1.125e9, // 9
+        1.25e9,  // 10
+        2.5e9,   // 20
+        3.125e9, // 25
+        5.0e9,   // 40
+        6.25e9,  // 50
+    ]
+}
+
+lazy_static! {
+    static ref STATE: RwLock<HashMap<String, Arc<ClientBw>>> = RwLock::new(HashMap::new());
+
+    /// View A: peak per-client-IP egress throughput (bytes/sec) over any 100 ms
+    /// window since the last scrape.
+    pub static ref CLIENT_IP_PEAK_BYTES_PER_SEC: GaugeVec = GaugeVec::new(
+        Opts::new(
+            "cloudbreak_api_client_ip_peak_bytes_per_second",
+            "Peak per-client-IP egress throughput in bytes/sec over any 100ms window since the last scrape."
+        ),
+        &["client_ip"],
+    )
+    .unwrap();
+
+    /// View B: distribution of per-client-IP egress throughput (bytes/sec),
+    /// sampled over 100 ms windows.
+    pub static ref CLIENT_IP_THROUGHPUT_BYTES_PER_SEC: HistogramVec = HistogramVec::new(
+        HistogramOpts::new(
+            "cloudbreak_api_client_ip_throughput_bytes_per_second",
+            "Distribution of per-client-IP egress throughput in bytes/sec, sampled over 100ms windows."
+        )
+        .buckets(throughput_buckets()),
+        &["client_ip"],
+    )
+    .unwrap();
+}
+
+/// Register the bandwidth collectors and start the background sampler. Called
+/// once from `setup_metrics` (inside the tokio runtime). Registration and
+/// sampler startup are idempotent-safe to call once.
+pub fn register(registry: &Registry) {
+    registry
+        .register(Box::new(CLIENT_IP_PEAK_BYTES_PER_SEC.clone()))
+        .expect("client-ip peak gauge can't be registered");
+    registry
+        .register(Box::new(CLIENT_IP_THROUGHPUT_BYTES_PER_SEC.clone()))
+        .expect("client-ip throughput histogram can't be registered");
+    spawn_sampler();
+}
+
+/// The single hot-path call: attribute `bytes` of egress to `client_ip`'s
+/// currently-open 100 ms window. Cheap: a read-lock + atomic add on the fast
+/// path; a write-lock only when first seeing an IP (or routing overflow to
+/// [`OTHER_LABEL`]).
+pub fn record(client_ip: &str, bytes: u64) {
+    if bytes == 0 {
+        return;
+    }
+
+    // Fast path: entry already exists.
+    {
+        let map = STATE.read().unwrap();
+        if let Some(client) = map.get(client_ip) {
+            client.current.fetch_add(bytes, Ordering::Relaxed);
+            return;
+        }
+    }
+
+    // Slow path: create the entry (or bucket into "other" when at capacity).
+    let mut map = STATE.write().unwrap();
+    // Re-check under the write lock in case another thread inserted it.
+    if let Some(client) = map.get(client_ip) {
+        client.current.fetch_add(bytes, Ordering::Relaxed);
+        return;
+    }
+    let key = if map.len() < MAX_CLIENT_IPS {
+        client_ip.to_string()
+    } else {
+        OTHER_LABEL.to_string()
+    };
+    let client = map.entry(key).or_insert_with(|| Arc::new(ClientBw::new()));
+    client.current.fetch_add(bytes, Ordering::Relaxed);
+}
+
+/// Close the current 100 ms window for every tracked client: snapshot+reset the
+/// accumulator, fold it into the per-scrape running max (A), and record the
+/// window's throughput into the histogram (B).
+fn sample_once() {
+    // Snapshot the Arcs under a short read lock, then work lock-free.
+    let clients: Vec<(String, Arc<ClientBw>)> = {
+        let map = STATE.read().unwrap();
+        map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+    };
+
+    for (ip, client) in clients {
+        let closed = client.current.swap(0, Ordering::Relaxed);
+        if closed == 0 {
+            continue;
+        }
+        client.running_max.fetch_max(closed, Ordering::Relaxed);
+        let bytes_per_sec = closed as f64 * SLOT_HZ;
+        CLIENT_IP_THROUGHPUT_BYTES_PER_SEC
+            .with_label_values(&[&ip])
+            .observe(bytes_per_sec);
+    }
+}
+
+/// Spawn the 100 ms sampler task. Safe to call once from `setup_metrics`.
+pub fn spawn_sampler() {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_millis(SLOT_MS));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            sample_once();
+        }
+    });
+}
+
+/// Publish the peak gauge (A) at scrape time and reset the per-scrape running
+/// max. Called from the `/metrics` handler.
+pub fn refresh_gauges() {
+    let clients: Vec<(String, Arc<ClientBw>)> = {
+        let map = STATE.read().unwrap();
+        map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+    };
+
+    for (ip, client) in clients {
+        let peak_slot_bytes = client.running_max.swap(0, Ordering::Relaxed);
+        CLIENT_IP_PEAK_BYTES_PER_SEC
+            .with_label_values(&[&ip])
+            .set(peak_slot_bytes as f64 * SLOT_HZ);
+    }
+}

--- a/crates/api/src/modules/mod.rs
+++ b/crates/api/src/modules/mod.rs
@@ -3,5 +3,6 @@
  * Copyright 2025-2026 Triton One Limited. All rights reserved.
  */
 
+pub mod bandwidth;
 pub mod cache;
 pub mod vote_accounts_cache;

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -502,23 +502,21 @@ pub struct MetricsConfig {
     )]
     pub subscription_id_key: String,
 
+    /// Enable the per-client-IP egress bandwidth metrics module (peak gauge +
+    /// throughput histogram). Off by default.
+    #[serde(rename = "client-ip-bandwidth-enabled", default)]
+    pub client_ip_bandwidth_enabled: bool,
+
     /// Request header carrying the client IP used to group the per-client-IP
-    /// bandwidth metrics. Defaults to the load-balancer IP header `client-ip`;
-    /// override to match your ingress (e.g. `x-forwarded-for`, `x-real-ip`).
-    #[serde(
-        rename = "client-ip-key",
-        default = "MetricsConfig::default_client_ip_key"
-    )]
-    pub client_ip_key: String,
+    /// bandwidth metrics. When unset — or when the header is absent on a
+    /// request — all bandwidth folds into a single placeholder label.
+    #[serde(rename = "client-ip-key", default)]
+    pub client_ip_key: Option<String>,
 }
 
 impl MetricsConfig {
     fn default_subscription_id_key() -> String {
         "x-subscription-id".to_string()
-    }
-
-    fn default_client_ip_key() -> String {
-        "client-ip".to_string()
     }
 }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -501,11 +501,24 @@ pub struct MetricsConfig {
         default = "MetricsConfig::default_subscription_id_key"
     )]
     pub subscription_id_key: String,
+
+    /// Request header carrying the client IP used to group the per-client-IP
+    /// bandwidth metrics. Defaults to the load-balancer IP header `client-ip`;
+    /// override to match your ingress (e.g. `x-forwarded-for`, `x-real-ip`).
+    #[serde(
+        rename = "client-ip-key",
+        default = "MetricsConfig::default_client_ip_key"
+    )]
+    pub client_ip_key: String,
 }
 
 impl MetricsConfig {
     fn default_subscription_id_key() -> String {
         "x-subscription-id".to_string()
+    }
+
+    fn default_client_ip_key() -> String {
+        "client-ip".to_string()
     }
 }
 

--- a/crates/integration_tests/README.md
+++ b/crates/integration_tests/README.md
@@ -5,6 +5,7 @@ Benchmarking and correctness testing tool for Solana RPC endpoints.
 ## Features
 
 - **Constant-rate load generation**: Spawns requests at a configurable RPS rate decoupled from response latency. A ticker fires at the target interval and dispatches requests regardless of how long previous ones take, with a semaphore limiting maximum in-flight concurrency.
+- **Bandwidth limit (Gbit/s)**: An optional `[benchmark].target_gbits` cap throttles load based on the **actual received rpc1 response bytes**, acting as a second ceiling alongside `target_rps`. If byte throughput reaches the cap below the target RPS, the spawner slows down so the average stays under the limit — useful for reproducing a link/NIC saturation ceiling instead of a pure request-rate one. Implemented as a debt-based token bucket over real wire bytes (no estimation). The run's **average Gbit/s** is always reported in the summary next to Effective RPS, whether or not a cap is set.
 - **Response comparison**: Optionally sends the same request to a second endpoint and compares the responses. Comparison is order-agnostic — accounts are matched by pubkey, so different ordering between endpoints is not flagged as a mismatch.
 - **Slot compensation**: When two endpoints return different data, the tool checks if the difference is due to a slot lag. If enabled, it fires concurrent requests to **both** endpoints at regular intervals, collecting all responses. It then searches for the first pair (one from each endpoint) that share the same slot, and uses that pair for comparison. This avoids the ping-pong problem where sequential retries on the behind endpoint can never converge because the chain keeps advancing (especially with `processed` commitment). The initial slot difference is still recorded in statistics. **Important**: slot compensation only activates when both responses include `result.context.slot` (i.e. the request was made with `withContext: true`). If the responses have no context, mismatches are reported as-is with no retries. For `getProgramAccounts`, context is only present if the request explicitly includes `withContext: true`; `getTokenAccountsByOwner` and `getTokenAccountsByDelegate` always return context.
 - **Live request sources**: Requests can come from a static JSON file or be fetched live from VictoriaLogs. The VictoriaLogs source refreshes every 60 seconds in the background, so the request pool evolves during long runs.
@@ -151,6 +152,7 @@ Controls load generation.
 | `target_rps`    | _(required)_ | Target requests per second. Requests are spawned at this rate independently of response latency |
 | `max_in_flight` | `100`        | Maximum concurrent in-flight requests. Requests beyond this limit are dropped                   |
 | `duration_secs` | `0`          | How long to run in seconds. `0` exits immediately (should be set)                               |
+| `target_gbits`  | _(none)_     | Optional bandwidth cap in **Gbit/s**, enforced against the actual received rpc1 response bytes. Works together with `target_rps`: if throughput hits this limit below the target RPS, effective RPS is throttled so the average stays under the cap. Omit (or `0`) to disable — the average Gbit/s is still reported either way |
 
 ### `[source]`
 
@@ -671,7 +673,7 @@ At the end of a run, a summary is printed to stdout. It has three sections:
 ==========================================================================================
 BENCHMARK SUMMARY
 ==========================================================================================
-Duration: 100.0s | Total requests: 1847 | Effective RPS: 18.5
+Duration: 100.0s | Total requests: 1847 | Effective RPS: 18.5 | Avg: 3.421 Gbit/s (cap 5.000 Gbit/s)
 Dropped requests (backpressure): 53 (2.8% of attempted)
 Comparisons: 1423 matches, 5 mismatches, 7 no-context mismatches (possible slot lag)
 Recovered by retry: 18 (would have been mismatches without retry_in_place) (1.26% of compared)
@@ -684,6 +686,7 @@ The **Recovered by retry** line is only printed when `[retry_in_place]` is enabl
 | Duration         | Actual wall-clock time of the run                                                                                                                                                                                                           |
 | Total requests   | Total number of requests sent (to both endpoints combined)                                                                                                                                                                                  |
 | Effective RPS    | `total_requests / duration` — the actual throughput achieved                                                                                                                                                                                |
+| Avg Gbit/s       | Average rpc1 throughput over the run, computed from the actual received response wire bytes (`total_rpc1_bytes * 8 / duration / 1e9`). When `target_gbits` is set, the configured cap is shown in parentheses                                 |
 | Dropped requests | Requests that were not sent because `max_in_flight` was full (only shown if > 0). This can indicate that `max_in_flight` is too low for the target RPS, or that the server is responding too slowly and in-flight requests are accumulating |
 | Comparisons      | Match/mismatch/no-context mismatch counts. No-context mismatches are responses that differ but lack `result.context`, meaning the difference may be due to slot lag that cannot be verified or compensated for                              |
 
@@ -753,6 +756,8 @@ name = "reference"
 target_rps = 5.0
 max_in_flight = 100
 duration_secs = 100
+# target_gbits = 1.0  # Optional bandwidth cap (Gbit/s) enforced on actual
+                      # received rpc1 bytes; throttles RPS to stay under it.
 
 [source]
 type = "json_file"

--- a/crates/integration_tests/src/bandwidth.rs
+++ b/crates/integration_tests/src/bandwidth.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! Bandwidth metering for the benchmark.
+//!
+//! A single shared [`BwMeter`] does two jobs:
+//!  1. Accumulates the total rpc1 bytes actually received off the wire, used to
+//!     print the average Gbit/s in the summary (works regardless of any limit).
+//!  2. Optionally enforces a `target_gbits` cap via a debt-based token bucket:
+//!     every received byte is subtracted from the bucket, and the spawner calls
+//!     [`BwMeter::acquire`] before dispatching each request, sleeping while the
+//!     bucket is in debt. This throttles effective RPS below `target_rps`
+//!     exactly when bandwidth — not request rate — is the binding constraint.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+/// Debt-based token bucket over *bytes*. `tokens` may go negative; the spawner
+/// waits out the debt before dispatching more work.
+struct TokenBucket {
+    /// Available byte budget; negative means we've overspent and must wait.
+    tokens: f64,
+    /// Burst ceiling (bytes) the bucket refills up to.
+    capacity: f64,
+    /// Refill rate in bytes per second (`target_gbits * 1e9 / 8`).
+    refill_per_sec: f64,
+    last: Instant,
+}
+
+impl TokenBucket {
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.refill_per_sec).min(self.capacity);
+        self.last = now;
+    }
+}
+
+pub struct BwMeter {
+    /// Total rpc1 bytes received off the wire (for the summary average).
+    total_bytes: AtomicU64,
+    /// `None` disables throttling — the meter then only totals bytes.
+    limiter: Option<Mutex<TokenBucket>>,
+}
+
+impl BwMeter {
+    /// `target_gbits` = optional cap in Gbit/s; `burst_secs` sizes the burst
+    /// capacity (how many seconds' worth of budget can accrue while idle).
+    pub fn new(target_gbits: Option<f64>, burst_secs: f64) -> Self {
+        let limiter = target_gbits
+            .filter(|g| *g > 0.0)
+            .map(|gbits| {
+                let refill_per_sec = gbits * 1e9 / 8.0;
+                let capacity = refill_per_sec * burst_secs;
+                Mutex::new(TokenBucket {
+                    tokens: capacity,
+                    capacity,
+                    refill_per_sec,
+                    last: Instant::now(),
+                })
+            });
+        Self {
+            total_bytes: AtomicU64::new(0),
+            limiter,
+        }
+    }
+
+    /// Account `bytes` actually received from rpc1. Always totals; also charges
+    /// the token bucket when a limit is configured.
+    pub fn record(&self, bytes: u64) {
+        self.total_bytes.fetch_add(bytes, Ordering::Relaxed);
+        if let Some(bucket) = &self.limiter {
+            let mut tb = bucket.lock().unwrap();
+            tb.refill();
+            tb.tokens -= bytes as f64;
+        }
+    }
+
+    /// Block until there is positive byte budget. No-op when no limit is set.
+    pub async fn acquire(&self) {
+        let Some(bucket) = &self.limiter else {
+            return;
+        };
+        loop {
+            let wait_secs = {
+                let mut tb = bucket.lock().unwrap();
+                tb.refill();
+                if tb.tokens > 0.0 {
+                    return;
+                }
+                -tb.tokens / tb.refill_per_sec
+            };
+            // Clamp so we always make forward progress even for tiny debts.
+            tokio::time::sleep(Duration::from_secs_f64(wait_secs.clamp(0.001, 5.0))).await;
+        }
+    }
+
+    pub fn total_bytes(&self) -> u64 {
+        self.total_bytes.load(Ordering::Relaxed)
+    }
+}

--- a/crates/integration_tests/src/bandwidth.rs
+++ b/crates/integration_tests/src/bandwidth.rs
@@ -5,26 +5,36 @@
 
 //! Bandwidth metering for the benchmark.
 //!
-//! A single shared [`BwMeter`] does two jobs:
-//!  1. Accumulates the total rpc1 bytes actually received off the wire, used to
-//!     print the average Gbit/s in the summary (works regardless of any limit).
-//!  2. Optionally enforces a `target_gbits` cap via a debt-based token bucket:
-//!     every received byte is subtracted from the bucket, and the spawner calls
-//!     [`BwMeter::acquire`] before dispatching each request, sleeping while the
-//!     bucket is in debt. This throttles effective RPS below `target_rps`
-//!     exactly when bandwidth — not request rate — is the binding constraint.
+//! A single shared [`BwMeter`] does two independent jobs:
+//!  1. **Pacing (behavioural).** When `target_gbits` is set, it enforces the cap
+//!     via a zero-burst token bucket paced entirely off the *estimated* response
+//!     size (the VictoriaLogs `bytes` field). The spawner calls
+//!     [`BwMeter::acquire_for`] with each dispatched request's estimate; the
+//!     bucket charges that estimate up front and blocks the next dispatch until
+//!     the debt has refilled. Because the charge happens at dispatch (not on
+//!     receipt), the gate throttles *before* the bytes land, which flattens the
+//!     sub-second spikes a receipt-driven limiter can't catch. No burst budget
+//!     ever accrues, so dispatch is smoothed to the cap rate.
+//!  2. **Stats (informational only).** Two running totals are kept and printed
+//!     side by side in the summary: the *estimated* bytes (what pacing used) and
+//!     the *real* bytes actually received off the wire ([`BwMeter::record`]).
+//!     The real total never influences pacing — it's there so you can see how
+//!     far the estimate deviated from reality.
+//!
+//! The cap only applies to requests that carry an estimate (VictoriaLogs);
+//! requests without one (`json_file`, mismatch dir) are never charged and run
+//! uncapped.
 
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-/// Debt-based token bucket over *bytes*. `tokens` may go negative; the spawner
-/// waits out the debt before dispatching more work.
+/// Zero-burst token bucket over *bytes*. `tokens` is clamped at 0 on refill so
+/// no budget ever accrues while idle (no bursting); it only goes negative as
+/// dispatches charge their estimate, and the spawner waits the debt out.
 struct TokenBucket {
-    /// Available byte budget; negative means we've overspent and must wait.
+    /// Byte budget; never positive (clamped to 0), negative means in debt.
     tokens: f64,
-    /// Burst ceiling (bytes) the bucket refills up to.
-    capacity: f64,
     /// Refill rate in bytes per second (`target_gbits * 1e9 / 8`).
     refill_per_sec: f64,
     last: Instant,
@@ -34,61 +44,58 @@ impl TokenBucket {
     fn refill(&mut self) {
         let now = Instant::now();
         let elapsed = now.duration_since(self.last).as_secs_f64();
-        self.tokens = (self.tokens + elapsed * self.refill_per_sec).min(self.capacity);
+        // Clamp at 0: no burst budget ever accrues.
+        self.tokens = (self.tokens + elapsed * self.refill_per_sec).min(0.0);
         self.last = now;
     }
 }
 
 pub struct BwMeter {
-    /// Total rpc1 bytes received off the wire (for the summary average).
-    total_bytes: AtomicU64,
-    /// `None` disables throttling — the meter then only totals bytes.
+    /// Sum of *estimated* response bytes for dispatched requests (pacing basis
+    /// and the "estimated" summary figure).
+    est_bytes: AtomicU64,
+    /// Sum of *actual* response bytes received off the wire (the "real" summary
+    /// figure only — never affects pacing).
+    actual_bytes: AtomicU64,
+    /// `None` disables pacing — the meter then only accumulates the two totals.
     limiter: Option<Mutex<TokenBucket>>,
 }
 
 impl BwMeter {
-    /// `target_gbits` = optional cap in Gbit/s; `burst_secs` sizes the burst
-    /// capacity (how many seconds' worth of budget can accrue while idle).
-    pub fn new(target_gbits: Option<f64>, burst_secs: f64) -> Self {
-        let limiter = target_gbits
-            .filter(|g| *g > 0.0)
-            .map(|gbits| {
-                let refill_per_sec = gbits * 1e9 / 8.0;
-                let capacity = refill_per_sec * burst_secs;
-                Mutex::new(TokenBucket {
-                    tokens: capacity,
-                    capacity,
-                    refill_per_sec,
-                    last: Instant::now(),
-                })
-            });
+    /// `target_gbits` = optional cap in Gbit/s. When set, pacing is enabled with
+    /// zero burst.
+    pub fn new(target_gbits: Option<f64>) -> Self {
+        let limiter = target_gbits.filter(|g| *g > 0.0).map(|gbits| {
+            Mutex::new(TokenBucket {
+                tokens: 0.0,
+                refill_per_sec: gbits * 1e9 / 8.0,
+                last: Instant::now(),
+            })
+        });
         Self {
-            total_bytes: AtomicU64::new(0),
+            est_bytes: AtomicU64::new(0),
+            actual_bytes: AtomicU64::new(0),
             limiter,
         }
     }
 
-    /// Account `bytes` actually received from rpc1. Always totals; also charges
-    /// the token bucket when a limit is configured.
-    pub fn record(&self, bytes: u64) {
-        self.total_bytes.fetch_add(bytes, Ordering::Relaxed);
-        if let Some(bucket) = &self.limiter {
-            let mut tb = bucket.lock().unwrap();
-            tb.refill();
-            tb.tokens -= bytes as f64;
+    /// Called once per dispatched request. Accumulates the estimate total and,
+    /// when both a cap and an estimate are present, paces: blocks while the
+    /// bucket is in debt, then charges `est`. Requests without an estimate
+    /// (`None`) are never charged and never blocked — the cap is VLogs-only.
+    pub async fn acquire_for(&self, est: Option<u64>) {
+        if let Some(est) = est {
+            self.est_bytes.fetch_add(est, Ordering::Relaxed);
         }
-    }
-
-    /// Block until there is positive byte budget. No-op when no limit is set.
-    pub async fn acquire(&self) {
-        let Some(bucket) = &self.limiter else {
+        let (Some(bucket), Some(est)) = (&self.limiter, est) else {
             return;
         };
         loop {
             let wait_secs = {
                 let mut tb = bucket.lock().unwrap();
                 tb.refill();
-                if tb.tokens > 0.0 {
+                if tb.tokens >= 0.0 {
+                    tb.tokens -= est as f64;
                     return;
                 }
                 -tb.tokens / tb.refill_per_sec
@@ -98,7 +105,19 @@ impl BwMeter {
         }
     }
 
-    pub fn total_bytes(&self) -> u64 {
-        self.total_bytes.load(Ordering::Relaxed)
+    /// Account `bytes` actually received from rpc1. Feeds the "real" stat only;
+    /// never touches the token bucket.
+    pub fn record(&self, bytes: u64) {
+        self.actual_bytes.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Total *estimated* rpc1 bytes for dispatched requests (pacing basis).
+    pub fn est_bytes(&self) -> u64 {
+        self.est_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Total *actual* rpc1 bytes received off the wire.
+    pub fn actual_bytes(&self) -> u64 {
+        self.actual_bytes.load(Ordering::Relaxed)
     }
 }

--- a/crates/integration_tests/src/benchmark.rs
+++ b/crates/integration_tests/src/benchmark.rs
@@ -62,7 +62,13 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
         duration_secs,
         timeout_secs,
         start_on_first_request,
+        target_gbits,
     } = benchmark;
+
+    // Shared bandwidth meter: always totals rpc1 received bytes (for the summary
+    // average) and, when `target_gbits` is set, enforces the cap via a debt-based
+    // token bucket. `burst_secs = 1.0` allows up to ~1s worth of budget to accrue.
+    let bw_meter = Arc::new(crate::bandwidth::BwMeter::new(target_gbits, 1.0));
 
     let retry_with_context = source.retry_with_context();
     let replay_once = source.replay_once();
@@ -104,6 +110,7 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
     let dropped_count_spawner = dropped_count.clone();
     let rpc1_name = rpc1.name.clone();
     let retry_in_place_enabled = retry_in_place.enabled;
+    let bw_meter_spawner = bw_meter.clone();
 
     // Spawner loop (runs for `duration` seconds)
     tokio::spawn(async move {
@@ -121,6 +128,12 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
                 break;
             }
             ticker.tick().await;
+
+            // Bandwidth gate: when a Gbit/s cap is configured this blocks while
+            // the token bucket is in debt, throttling effective RPS below
+            // `target_rps` exactly when bandwidth is the binding constraint.
+            bw_meter_spawner.acquire().await;
+
             let permit = semaphore.clone().try_acquire_owned();
 
             let request = if replay_once {
@@ -163,6 +176,7 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
                     let print_config = print_config.clone();
                     let retry_in_place = retry_in_place.clone();
                     let db_probe_pool = db_probe_pool.clone();
+                    let bw_meter = bw_meter_spawner.clone();
 
                     tokio::spawn(async move {
                         if let Err(e) = process_request(
@@ -178,6 +192,7 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
                             retry_with_context,
                             &retry_in_place,
                             db_probe_pool.as_ref(),
+                            &bw_meter,
                         )
                         .await
                         {
@@ -200,7 +215,12 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
     }
 
     let dropped = dropped_count.load(std::sync::atomic::Ordering::Relaxed);
-    stats.print_summary(dropped, retry_in_place_enabled);
+    stats.print_summary(
+        dropped,
+        retry_in_place_enabled,
+        bw_meter.total_bytes(),
+        target_gbits,
+    );
 
     if stats.total_mismatches > 0 {
         anyhow::bail!(
@@ -259,14 +279,22 @@ async fn run_comparison(
     encoding: &str,
     retry_with_context: bool,
     db_probe_ctx: Option<&DbProbeCtx>,
+    bw_meter: &Arc<crate::bandwidth::BwMeter>,
 ) -> Result<ComparisonOutcome> {
     let mut iterations: Option<Vec<response_comparison::IterationCapture>> = comparison_config
         .save_compensation_iterations
         .then(Vec::new);
 
     let initial_fired_at = SystemTime::now();
-    let (r1, r2, initial_probe) =
-        response_comparison::join_pair_with_probe(client, rpc1, rpc2, request, db_probe_ctx).await;
+    let (r1, r2, initial_probe) = response_comparison::join_pair_with_probe(
+        client,
+        rpc1,
+        rpc2,
+        request,
+        db_probe_ctx,
+        bw_meter,
+    )
+    .await;
     let (json1, duration1) = r1?;
     let (json2, duration2) = r2?;
 
@@ -299,6 +327,7 @@ async fn run_comparison(
         iterations.as_mut(),
         "initial",
         db_probe_ctx,
+        bw_meter,
     )
     .await?;
 
@@ -317,6 +346,7 @@ async fn run_comparison(
             rpc2,
             &ctx_request,
             db_probe_ctx,
+            bw_meter,
         )
         .await;
         let (ctx_json1, ctx_dur1) = ctx_r1?;
@@ -351,6 +381,7 @@ async fn run_comparison(
             iterations.as_mut(),
             "with_context_retry",
             db_probe_ctx,
+            bw_meter,
         )
         .await?;
 
@@ -380,6 +411,7 @@ async fn process_request(
     retry_with_context: bool,
     retry_in_place: &RetryInPlaceConfig,
     db_probe_pool: Option<&Arc<sea_orm::DatabaseConnection>>,
+    bw_meter: &Arc<crate::bandwidth::BwMeter>,
 ) -> Result<()> {
     let encoding = utils::extract_encoding_from_request(request, request_type);
     let commitment = utils::extract_commitment_from_request(request, request_type);
@@ -401,7 +433,7 @@ async fn process_request(
 
     // Comparison-disabled path keeps the legacy one-sided behavior (just rpc1).
     let Some(comparison_config) = comparison_config else {
-        let (json, duration) = utils::send_rpc_request(client, rpc1, request).await?;
+        let (json, duration) = utils::send_rpc_request(client, rpc1, request, Some(bw_meter)).await?;
         utils::print_request_result(request, duration, &json, rpc1, &encoding, print_config);
         if let Err(e) = results_tx.send(BenchResult {
             duration,
@@ -442,6 +474,7 @@ async fn process_request(
         let comparison_config = comparison_config.clone();
         let encoding = encoding.clone();
         let db_probe_ctx = db_probe_ctx.clone();
+        let bw_meter = bw_meter.clone();
         Some(tokio::spawn(async move {
             tokio::time::sleep_until(fire_at).await;
             run_comparison(
@@ -454,6 +487,7 @@ async fn process_request(
                 &encoding,
                 retry_with_context,
                 db_probe_ctx.as_ref(),
+                &bw_meter,
             )
             .await
         }))
@@ -472,6 +506,7 @@ async fn process_request(
         &encoding,
         retry_with_context,
         db_probe_ctx_ref,
+        bw_meter,
     )
     .await?;
     let original_elapsed_ms = original_start.elapsed().as_millis();
@@ -531,6 +566,7 @@ async fn process_request(
             &encoding,
             retry_with_context,
             db_probe_ctx_ref,
+            bw_meter,
         )
         .await
         {
@@ -769,17 +805,32 @@ impl BenchStats {
         self.buckets.entry(key).or_default().push(result.duration);
     }
 
-    fn print_summary(&mut self, dropped: u64, retry_in_place_enabled: bool) {
+    fn print_summary(
+        &mut self,
+        dropped: u64,
+        retry_in_place_enabled: bool,
+        total_rpc1_bytes: u64,
+        target_gbits: Option<f64>,
+    ) {
         let elapsed = self.start_time.elapsed();
+
+        // Average rpc1 throughput over the run, from actual received wire bytes.
+        let avg_gbits = total_rpc1_bytes as f64 * 8.0 / elapsed.as_secs_f64() / 1e9;
 
         println!("\n{}", "=".repeat(90));
         println!("BENCHMARK SUMMARY");
         println!("{}", "=".repeat(90));
+        let gbits_cap = target_gbits
+            .filter(|g| *g > 0.0)
+            .map(|g| format!(" (cap {g:.3} Gbit/s)"))
+            .unwrap_or_default();
         println!(
-            "Duration: {:.1}s | Total requests: {} | Effective RPS: {:.1}",
+            "Duration: {:.1}s | Total requests: {} | Effective RPS: {:.1} | Avg: {:.3} Gbit/s{}",
             elapsed.as_secs_f64(),
             self.total_requests,
             self.total_requests as f64 / elapsed.as_secs_f64(),
+            avg_gbits,
+            gbits_cap,
         );
 
         if dropped > 0 {

--- a/crates/integration_tests/src/benchmark.rs
+++ b/crates/integration_tests/src/benchmark.rs
@@ -65,10 +65,10 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
         target_gbits,
     } = benchmark;
 
-    // Shared bandwidth meter: always totals rpc1 received bytes (for the summary
-    // average) and, when `target_gbits` is set, enforces the cap via a debt-based
-    // token bucket. `burst_secs = 1.0` allows up to ~1s worth of budget to accrue.
-    let bw_meter = Arc::new(crate::bandwidth::BwMeter::new(target_gbits, 1.0));
+    // Shared bandwidth meter: always totals both estimated and actual rpc1 bytes
+    // (for the summary) and, when `target_gbits` is set, paces dispatch with a
+    // zero-burst token bucket charged off each request's estimated size.
+    let bw_meter = Arc::new(crate::bandwidth::BwMeter::new(target_gbits));
 
     let retry_with_context = source.retry_with_context();
     let replay_once = source.replay_once();
@@ -117,7 +117,7 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
         let mut deadline = (!start_on_first_request)
             .then(|| Instant::now() + Duration::from_secs(duration_secs));
         let mut idx: usize = 0;
-        let mut pending: VecDeque<serde_json::Value> = VecDeque::new();
+        let mut pending: VecDeque<sources::BenchRequest> = VecDeque::new();
         let mut drained_initial = false;
 
         // Will make the requests loop infinitely until the deadline is reached
@@ -128,11 +128,6 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
                 break;
             }
             ticker.tick().await;
-
-            // Bandwidth gate: when a Gbit/s cap is configured this blocks while
-            // the token bucket is in debt, throttling effective RPS below
-            // `target_rps` exactly when bandwidth is the binding constraint.
-            bw_meter_spawner.acquire().await;
 
             let permit = semaphore.clone().try_acquire_owned();
 
@@ -157,6 +152,11 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
                 req
             };
 
+            // Split off the bandwidth estimate; the rest of the pipeline only
+            // needs the request body (`JsonValue`), so shadow `request`.
+            let est_bytes = request.est_bytes;
+            let request = request.body;
+
             if deadline.is_none() {
                 tracing::info!(
                     target: "bench_source",
@@ -167,6 +167,12 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
 
             match permit {
                 Ok(permit) => {
+                    // Bandwidth gate: charge this dispatch's estimate and, when a
+                    // Gbit/s cap is configured, block until the zero-burst bucket
+                    // has refilled. Only dispatched (non-dropped) requests are
+                    // charged. No-op for requests without an estimate.
+                    bw_meter_spawner.acquire_for(est_bytes).await;
+
                     let tx = tx.clone();
                     let client = client.clone();
                     let rpc1 = rpc1.clone();
@@ -218,7 +224,8 @@ pub async fn run(args: &BenchmarkArgs) -> Result<()> {
     stats.print_summary(
         dropped,
         retry_in_place_enabled,
-        bw_meter.total_bytes(),
+        bw_meter.est_bytes(),
+        bw_meter.actual_bytes(),
         target_gbits,
     );
 
@@ -809,13 +816,18 @@ impl BenchStats {
         &mut self,
         dropped: u64,
         retry_in_place_enabled: bool,
-        total_rpc1_bytes: u64,
+        est_rpc1_bytes: u64,
+        actual_rpc1_bytes: u64,
         target_gbits: Option<f64>,
     ) {
         let elapsed = self.start_time.elapsed();
 
-        // Average rpc1 throughput over the run, from actual received wire bytes.
-        let avg_gbits = total_rpc1_bytes as f64 * 8.0 / elapsed.as_secs_f64() / 1e9;
+        // Average rpc1 throughput over the run. `est` is what pacing used (the
+        // VLogs `bytes` estimate); `real` is the actual received wire bytes —
+        // shown side by side so estimate drift is visible.
+        let secs = elapsed.as_secs_f64();
+        let est_gbits = est_rpc1_bytes as f64 * 8.0 / secs / 1e9;
+        let real_gbits = actual_rpc1_bytes as f64 * 8.0 / secs / 1e9;
 
         println!("\n{}", "=".repeat(90));
         println!("BENCHMARK SUMMARY");
@@ -825,12 +837,13 @@ impl BenchStats {
             .map(|g| format!(" (cap {g:.3} Gbit/s)"))
             .unwrap_or_default();
         println!(
-            "Duration: {:.1}s | Total requests: {} | Effective RPS: {:.1} | Avg: {:.3} Gbit/s{}",
-            elapsed.as_secs_f64(),
+            "Duration: {:.1}s | Total requests: {} | Effective RPS: {:.1} | Est: {:.3} Gbit/s{} | Real: {:.3} Gbit/s",
+            secs,
             self.total_requests,
-            self.total_requests as f64 / elapsed.as_secs_f64(),
-            avg_gbits,
+            self.total_requests as f64 / secs,
+            est_gbits,
             gbits_cap,
+            real_gbits,
         );
 
         if dropped > 0 {

--- a/crates/integration_tests/src/config.rs
+++ b/crates/integration_tests/src/config.rs
@@ -91,6 +91,10 @@ pub enum SourceConfig {
         min_request_size: Option<u64>,
         max_request_size: Option<u64>,
         encoding: Option<String>,
+        /// Value for the `pool_dedicated` VictoriaLogs filter (e.g. `"liquid"`).
+        /// When omitted, no `pool_dedicated` constraint is added to the query.
+        #[serde(default)]
+        pool_dedicated: Option<String>,
         /// If true, when a no-context mismatch is detected, re-sends the request
         /// with `withContext: true` injected and runs slot compensation before
         /// deciding whether it's a real mismatch.

--- a/crates/integration_tests/src/config.rs
+++ b/crates/integration_tests/src/config.rs
@@ -65,6 +65,13 @@ pub struct BenchmarkConfig {
 
     #[serde(default)]
     pub start_on_first_request: bool,
+
+    /// Optional bandwidth cap in Gbit/s, enforced against *actual received*
+    /// rpc1 response bytes. Acts as an upper bound together with `target_rps`:
+    /// if byte throughput hits this limit below `target_rps`, effective RPS is
+    /// reduced so the average stays under the cap. Omit/0 to disable.
+    #[serde(default)]
+    pub target_gbits: Option<f64>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/crates/integration_tests/src/main.rs
+++ b/crates/integration_tests/src/main.rs
@@ -5,6 +5,7 @@
 
 use clap::{Parser, Subcommand};
 
+mod bandwidth;
 mod benchmark;
 mod compare_accounts_by_mint;
 mod compare_accounts_by_mint_vs_cluster;

--- a/crates/integration_tests/src/response_comparison.rs
+++ b/crates/integration_tests/src/response_comparison.rs
@@ -416,24 +416,27 @@ pub async fn join_pair_with_probe(
     rpc2: &RpcEndpoint,
     request: &JsonValue,
     db_probe_ctx: Option<&DbProbeCtx>,
+    bw_meter: &std::sync::Arc<crate::bandwidth::BwMeter>,
 ) -> (
     Result<(JsonValue, u128)>,
     Result<(JsonValue, u128)>,
     Option<DbProbeResult>,
 ) {
+    // Only rpc1 (the endpoint under test) is metered for the Gbit/s limit and
+    // the average throughput display; rpc2 is the comparison arm.
     match db_probe_ctx {
         Some(ctx) => {
             let (r1, r2, probe) = tokio::join!(
-                utils::send_rpc_request(client, rpc1, request),
-                utils::send_rpc_request(client, rpc2, request),
+                utils::send_rpc_request(client, rpc1, request, Some(bw_meter)),
+                utils::send_rpc_request(client, rpc2, request, None),
                 probe_get_balance_state(ctx),
             );
             (r1, r2, probe)
         }
         None => {
             let (r1, r2) = tokio::join!(
-                utils::send_rpc_request(client, rpc1, request),
-                utils::send_rpc_request(client, rpc2, request),
+                utils::send_rpc_request(client, rpc1, request, Some(bw_meter)),
+                utils::send_rpc_request(client, rpc2, request, None),
             );
             (r1, r2, None)
         }
@@ -463,6 +466,7 @@ pub async fn compare_with_slot_compensation(
     mut iterations: Option<&mut Vec<IterationCapture>>,
     iteration_phase: &'static str,
     db_probe_ctx: Option<&DbProbeCtx>,
+    bw_meter: &std::sync::Arc<crate::bandwidth::BwMeter>,
 ) -> Result<(CompareResponsesResult, u32)> {
     let enable_slot_compensation = comparison_config.enable_slot_compensation;
     let max_retries = comparison_config.slot_compensation_max_retries;
@@ -506,6 +510,7 @@ pub async fn compare_with_slot_compensation(
                         rpc2,
                         request,
                         db_probe_ctx,
+                        bw_meter,
                     )
                     .await;
 

--- a/crates/integration_tests/src/sources/json_file.rs
+++ b/crates/integration_tests/src/sources/json_file.rs
@@ -6,10 +6,20 @@
 use serde_json::Value as JsonValue;
 use tokio::sync::watch;
 
+use crate::sources::BenchRequest;
+
 /// The Json file can contain any type of valid request and it will be sent as it is to the RPC endpoints
-pub fn load_requests(path: &str) -> Result<watch::Receiver<Vec<JsonValue>>, anyhow::Error> {
+pub fn load_requests(path: &str) -> Result<watch::Receiver<Vec<BenchRequest>>, anyhow::Error> {
     let file_content = std::fs::read_to_string(path)?;
     let requests: Vec<JsonValue> = serde_json::from_str(&file_content)?;
+    // No size estimate available for this source → uncapped.
+    let requests: Vec<BenchRequest> = requests
+        .into_iter()
+        .map(|body| BenchRequest {
+            body,
+            est_bytes: None,
+        })
+        .collect();
 
     // _tx is dropped — JsonFile is static, no updates
     let (_tx, rx) = watch::channel(requests);

--- a/crates/integration_tests/src/sources/mismatch_files.rs
+++ b/crates/integration_tests/src/sources/mismatch_files.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use serde_json::Value as JsonValue;
 use tokio::sync::watch;
 
+use crate::sources::BenchRequest;
 use crate::utils;
 
 /// Reads all `mismatch_*.json` files from a directory and extracts the `request`
@@ -16,7 +17,7 @@ use crate::utils;
 /// its params object (creates the object if needed). This is necessary for GPA
 /// requests that were originally sent without context, so that slot compensation
 /// can work on the re-run.
-pub fn load_requests(dir: &str, inject_context: bool) -> Result<watch::Receiver<Vec<JsonValue>>> {
+pub fn load_requests(dir: &str, inject_context: bool) -> Result<watch::Receiver<Vec<BenchRequest>>> {
     let entries: Vec<_> = std::fs::read_dir(dir)
         .with_context(|| format!("Failed to read mismatch directory: {dir}"))?
         .filter_map(|e| e.ok())
@@ -39,7 +40,11 @@ pub fn load_requests(dir: &str, inject_context: bool) -> Result<watch::Receiver<
             if inject_context {
                 utils::inject_with_context(&mut request);
             }
-            requests.push(request);
+            // No size estimate available for this source → uncapped.
+            requests.push(BenchRequest {
+                body: request,
+                est_bytes: None,
+            });
         } else {
             tracing::warn!(
                 target: "bench_source",

--- a/crates/integration_tests/src/sources/mod.rs
+++ b/crates/integration_tests/src/sources/mod.rs
@@ -15,13 +15,28 @@ use anyhow::Result;
 use serde_json::Value as JsonValue;
 use tokio::sync::watch;
 
+/// A request to benchmark plus an optional estimated response size in bytes.
+///
+/// `est_bytes` is populated only by the VictoriaLogs source (from its `bytes`
+/// field) and drives the bandwidth cap. Other sources leave it `None`, so those
+/// requests run uncapped.
+#[derive(Clone, Debug)]
+pub struct BenchRequest {
+    pub body: JsonValue,
+    pub est_bytes: Option<u64>,
+}
+
 fn retain_unseen(
     requests: Vec<victoria_logs::LoggedRequest>,
     seen: &mut HashSet<String>,
     replay_once: bool,
-) -> Vec<JsonValue> {
+) -> Vec<BenchRequest> {
+    let to_bench = |r: victoria_logs::LoggedRequest| BenchRequest {
+        body: r.body,
+        est_bytes: r.bytes,
+    };
     if !replay_once {
-        return requests.into_iter().map(|r| r.body).collect();
+        return requests.into_iter().map(to_bench).collect();
     }
     requests
         .into_iter()
@@ -29,7 +44,7 @@ fn retain_unseen(
             Some(id) => seen.insert(id.clone()),
             None => true,
         })
-        .map(|r| r.body)
+        .map(to_bench)
         .collect()
 }
 
@@ -37,7 +52,7 @@ fn retain_unseen(
 pub async fn load_requests_from_source(
     source: &SourceConfig,
     request_type: RequestType,
-) -> Result<watch::Receiver<Vec<JsonValue>>, anyhow::Error> {
+) -> Result<watch::Receiver<Vec<BenchRequest>>, anyhow::Error> {
     match source {
         SourceConfig::JsonFile { path } => {
             let rx = json_file::load_requests(path)?;

--- a/crates/integration_tests/src/sources/mod.rs
+++ b/crates/integration_tests/src/sources/mod.rs
@@ -67,6 +67,7 @@ pub async fn load_requests_from_source(
             min_request_size,
             max_request_size,
             encoding,
+            pool_dedicated,
             inject_context: _,
             poll_interval_secs,
             replay_once,
@@ -93,6 +94,7 @@ pub async fn load_requests_from_source(
                 *minutes,
                 *window_seconds,
                 *limit,
+                pool_dedicated.as_deref(),
             )
             .await?;
             let initial_requests = retain_unseen(initial_requests, &mut seen, replay_once);
@@ -109,6 +111,7 @@ pub async fn load_requests_from_source(
             let min_request_size = *min_request_size;
             let max_request_size = *max_request_size;
             let encoding = encoding.clone();
+            let pool_dedicated = pool_dedicated.clone();
             let minutes = *minutes;
             let window_seconds = *window_seconds;
             let limit = *limit;
@@ -127,6 +130,7 @@ pub async fn load_requests_from_source(
                         minutes,
                         window_seconds,
                         limit,
+                        pool_dedicated.as_deref(),
                     )
                     .await
                     {

--- a/crates/integration_tests/src/sources/victoria_logs.rs
+++ b/crates/integration_tests/src/sources/victoria_logs.rs
@@ -11,6 +11,9 @@ use crate::utils;
 pub struct LoggedRequest {
     pub req_id: Option<String>,
     pub body: JsonValue,
+    /// Logged response size in bytes (the VictoriaLogs `bytes` field), used as
+    /// the bandwidth-cap estimate. `None` when the field is absent/unparseable.
+    pub bytes: Option<u64>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -130,6 +133,10 @@ pub async fn get_requests(
             }
 
             let req_id = log["req_id"].as_str().map(String::from);
+            // VictoriaLogs may emit `bytes` as a JSON number or a string.
+            let bytes = log["bytes"]
+                .as_u64()
+                .or_else(|| log["bytes"].as_str().and_then(|s| s.parse::<u64>().ok()));
             let mut body: JsonValue = serde_json::from_str(log["body"].as_str().unwrap()).ok()?;
 
             if request_type == RequestType::GpaTokenMint
@@ -177,7 +184,11 @@ pub async fn get_requests(
                 }
             }
 
-            Some(LoggedRequest { req_id, body })
+            Some(LoggedRequest {
+                req_id,
+                body,
+                bytes,
+            })
         })
         .collect();
 

--- a/crates/integration_tests/src/sources/victoria_logs.rs
+++ b/crates/integration_tests/src/sources/victoria_logs.rs
@@ -25,9 +25,21 @@ pub fn get_body_query(
     minutes: Option<u32>,
     window_seconds: Option<u32>,
     limit: u32,
+    pool_dedicated: Option<&str>,
 ) -> String {
     let encoding_filter = encoding
         .map(|e| format!(r#" AND body:~`"encoding":\s*"{}"`"#, e))
+        .unwrap_or_default();
+
+    // `pool_dedicated` filter, configurable per source. When unset, no
+    // `pool_dedicated` constraint is applied. `simulateTransaction` keeps its
+    // historical `foundation` default when the config leaves it unset.
+    let pool_filter = pool_dedicated
+        .map(|p| format!(" AND pool_dedicated:~\"{}\"", p))
+        .unwrap_or_default();
+    let simulate_pool_filter = pool_dedicated
+        .or(Some("foundation"))
+        .map(|p| format!(" AND pool_dedicated:~\"{}\"", p))
         .unwrap_or_default();
 
     let time_filter = match window_seconds {
@@ -39,13 +51,13 @@ pub fn get_body_query(
 
     match request_type {
         RequestType::Gtabo => format!(
-            "query={time_filter}rpc_call:=\"getTokenAccountsByOwner\" {encoding_filter} AND pool_dedicated:~\"liquid\" {min_filter} {max_filter} | limit {limit}"
+            "query={time_filter}rpc_call:=\"getTokenAccountsByOwner\" {encoding_filter}{pool_filter} {min_filter} {max_filter} | limit {limit}"
         ),
         RequestType::Gtabd => format!(
-            "query={time_filter}rpc_call:=\"getTokenAccountsByDelegate\" {encoding_filter} AND pool_dedicated:~\"liquid\" {min_filter} {max_filter} | limit {limit}"
+            "query={time_filter}rpc_call:=\"getTokenAccountsByDelegate\" {encoding_filter}{pool_filter} {min_filter} {max_filter} | limit {limit}"
         ),
         RequestType::Gpa => format!(
-            "query={time_filter}rpc_call:=\"getProgramAccounts\"  AND pool_dedicated:~\"liquid\" AND NOT body:~\"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA|TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\" {encoding_filter} {min_filter} {max_filter} | limit {limit}"
+            "query={time_filter}rpc_call:=\"getProgramAccounts\" {pool_filter} AND NOT body:~\"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA|TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\" {encoding_filter} {min_filter} {max_filter} | limit {limit}"
         ),
         RequestType::GpaTokenOwner => format!(
             "query={time_filter}rpc_call:=\"getProgramAccounts\" {encoding_filter} AND b_end:~\"tokenowner\" AND body:~\"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA|TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\" AND body:~`memcmp.*offset.:\\s*32` | limit {limit}"
@@ -54,19 +66,19 @@ pub fn get_body_query(
             "query={time_filter}rpc_call:=\"getProgramAccounts\" {encoding_filter} AND b_end:~\"liquid-tokenmint\" AND body:~\"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA|TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\" AND body:~`memcmp.*offset.:\\s*0` | limit {limit}"
         ),
         RequestType::GetAccountInfo => format!(
-            "query={time_filter}rpc_call:=\"getAccountInfo\" AND pool_dedicated:~\"liquid\" | limit {limit}"
+            "query={time_filter}rpc_call:=\"getAccountInfo\"{pool_filter} | limit {limit}"
         ),
         RequestType::GetMultipleAccounts => format!(
-            "query={time_filter}rpc_call:=\"getMultipleAccounts\" AND pool_dedicated:~\"liquid\" | limit {limit}"
+            "query={time_filter}rpc_call:=\"getMultipleAccounts\"{pool_filter} | limit {limit}"
         ),
         RequestType::GetBalance => format!(
-            "query={time_filter}rpc_call:=\"getBalance\" AND pool_dedicated:~\"liquid\" | limit {limit}"
+            "query={time_filter}rpc_call:=\"getBalance\"{pool_filter} | limit {limit}"
         ),
         RequestType::GetTokenAccountBalance => format!(
-            "query={time_filter}rpc_call:=\"getTokenAccountBalance\" AND pool_dedicated:~\"liquid\" | limit {limit}"
+            "query={time_filter}rpc_call:=\"getTokenAccountBalance\"{pool_filter} | limit {limit}"
         ),
         RequestType::SimulateTransaction => format!(
-            "query={time_filter}rpc_call:=\"simulateTransaction\" AND pool_dedicated:~\"foundation\" AND body:* | limit {limit}"
+            "query={time_filter}rpc_call:=\"simulateTransaction\"{simulate_pool_filter} AND body:* | limit {limit}"
         ),
     }
 }
@@ -82,6 +94,7 @@ pub async fn get_requests(
     minutes: Option<u32>,
     window_seconds: Option<u32>,
     limit: u32,
+    pool_dedicated: Option<&str>,
 ) -> Result<Vec<LoggedRequest>, anyhow::Error> {
     let min_filter = if let Some(min_request_size) = min_request_size {
         format!(" AND bytes:>{}", min_request_size)
@@ -103,6 +116,7 @@ pub async fn get_requests(
         minutes,
         window_seconds,
         limit,
+        pool_dedicated,
     );
 
     let response = client

--- a/crates/integration_tests/src/utils.rs
+++ b/crates/integration_tests/src/utils.rs
@@ -19,6 +19,7 @@ pub async fn send_rpc_request(
     client: &reqwest::Client,
     endpoint: &RpcEndpoint,
     request: &JsonValue,
+    meter: Option<&std::sync::Arc<crate::bandwidth::BwMeter>>,
 ) -> Result<(JsonValue, u128)> {
     let start = Instant::now();
 
@@ -30,11 +31,23 @@ pub async fn send_rpc_request(
         .await
         .with_context(|| format!("Failed to connect to {}", endpoint.name))?;
 
-    let json = response
-        .json()
+    // Read the raw body first so we can account the true received wire size
+    // cheaply: `reqwest::Response::json()` already buffers the full body into
+    // `bytes()` internally, so doing it ourselves adds no extra copy — we just
+    // get `.len()` for free and parse from the slice. The re-serialized JSON
+    // length used for the size buckets is computed by the caller as before.
+    let body = response
+        .bytes()
         .await
         .with_context(|| format!("Failed to read response from {}", endpoint.name))?;
     let duration = start.elapsed().as_millis();
+
+    if let Some(meter) = meter {
+        meter.record(body.len() as u64);
+    }
+
+    let json = serde_json::from_slice(&body)
+        .with_context(|| format!("Failed to parse response from {}", endpoint.name))?;
 
     Ok((json, duration))
 }

--- a/example.cloudbreak.api.toml
+++ b/example.cloudbreak.api.toml
@@ -15,9 +15,13 @@ host = "0.0.0.0"
 port = 8875
 # Header used to identify the subscription for per-subscription metrics.
 # subscription-id-key = "x-subscription-id"
-# Header used to identify the client IP for the per-client-IP
-# bandwidth metrics. Override to match your ingress (e.g. "x-forwarded-for").
-# client-ip-key = "client-ip"
+# Optional per-client-IP egress bandwidth metrics (peak gauge + throughput
+# histogram). Off by default.
+# client-ip-bandwidth-enabled = false
+# Header used to group the per-client-IP bandwidth metrics. When unset (or when
+# a request lacks the header) all bandwidth folds into a single "unconfigured"
+# label. Set it to a trusted ingress header (e.g. "x-forwarded-for") to group by client IP.
+# client-ip-key = "x-forwarded-for"
 
 [query-tracker-client]
 endpoint = "http://localhost:4001"

--- a/example.cloudbreak.api.toml
+++ b/example.cloudbreak.api.toml
@@ -13,6 +13,11 @@ api-queries-timeout = 20
 [metrics]
 host = "0.0.0.0"
 port = 8875
+# Header used to identify the subscription for per-subscription metrics.
+# subscription-id-key = "x-subscription-id"
+# Header used to identify the client IP for the per-client-IP
+# bandwidth metrics. Override to match your ingress (e.g. "x-forwarded-for").
+# client-ip-key = "client-ip"
 
 [query-tracker-client]
 endpoint = "http://localhost:4001"

--- a/example.cloudbreak.integration_tests.toml
+++ b/example.cloudbreak.integration_tests.toml
@@ -11,6 +11,10 @@ target_rps = 5.0
 max_in_flight = 100
 duration_secs = 100
 timeout_secs = 60
+# Optional bandwidth cap in Gbit/s, enforced against actual received rpc1 bytes.
+# Works together with target_rps: if throughput hits this limit below target_rps,
+# effective RPS is throttled so the average stays under the cap. Omit to disable.
+# target_gbits = 1.0
 
 [source]
 type = "json_file"

--- a/example.cloudbreak.integration_tests.toml
+++ b/example.cloudbreak.integration_tests.toml
@@ -31,6 +31,7 @@ path = "crates/integration_tests/gpa_benchmark_requests.json"
 # # If set it will filter the requests by the encoding, if empty it will return all encodings
 # # "base64" | "base58" | "base64+zstd" | "jsonParsed"
 # encoding = "jsonParsed"
+# pool_dedicated = "liquid"  # Value for the `pool_dedicated` VictoriaLogs filter; omit for no constraint
 # inject_context = true  # On no-context mismatch, re-sends with withContext:true and slot compensation before deciding
 
 # Example of mismatch_dir source (re-run previously mismatched requests)


### PR DESCRIPTION
### What was added

**Integration tests** — Gbit/s bandwidth limit. Added an optional [benchmark].target_gbits cap that throttles load based on actual received rpc1 response bytes (debt-based token bucket), working alongside target_rps. The run's average Gbit/s is now printed in the summary next to Effective RPS. Response wire bytes are captured cheaply in send_rpc_request and metered via a new BwMeter.

**API**— per-client-IP bandwidth metrics. Added an encapsulated bandwidth module that attributes response bytes to 100 ms windows per client IP and exposes two metrics: a peak-throughput gauge (cloudbreak_api_client_ip_peak_bytes_per_second) and a throughput histogram (cloudbreak_api_client_ip_throughput_bytes_per_second), both in bytes/sec and capped at 100 distinct IPs. Added a configurable client-ip-key header (default client-ip) and a toggleable api_request_headers debug log line dumping the full request headers.