### PR TITLE
Add grpc reconnection retries and configurable node unhealthy http status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,23 @@ Example:
 processed-commitment = "use-confirmed"
 ```
 
+#### `unhealthy-response` (top-level, optional)
+
+Controls how the API responds to requests while the node is unhealthy (the `slots.health` flag is unset / the slot syncronizer reports unhealthy). This is a top-level key (not inside any section).
+
+| Value                | Description                                                                                                      |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `"json-rpc-error"`   | **(default)** Return a `NODE_UNHEALTHY` JSON-RPC error (code `-32005`) with HTTP `200 OK`.                        |
+| `"http-unavailable"` | Return an HTTP `503 Service Unavailable` response instead.                                                        |
+
+> **Note:** `http-unavailable` only applies to single requests. Batch requests always return HTTP `200 OK` with per-item JSON-RPC errors, since an HTTP status cannot be expressed per batch item.
+
+Example:
+
+```toml
+unhealthy-response = "http-unavailable"
+```
+
 #### `[tracing]` (optional)
 
 OpenTelemetry tracing configuration. If this section is omitted, OTel is disabled and only `tracing-subscriber` is used.

--- a/README.md
+++ b/README.md
@@ -381,6 +381,9 @@ Shared across all services. Controls the SeaORM/SQLx connection pool and query t
 | `chunk-size`           | `usize`  | `1000`            | Chunk size for subscription events.                                                  |
 | `max-chunk-bytes-data` | `usize`  | `2097152` (2 MiB) | Max bytes per data chunk.                                                            |
 | `max-grpc-errors`      | `usize`  | **required**      | Max gRPC errors before attempting reconnection (always reconnects on stream `None`). |
+| `reconnect-give-up`    | `Duration` | `"600s"`        | How long to keep retrying (re)connection/subscription before giving up and panicking. |
+| `reconnect-backoff`    | `Duration` | `"5s"`          | Delay between (re)connection/subscription attempts.                                  |
+| `reconnect-from-slot-retain` | `Duration` | `"300s"`  | How long a reconnection keeps replaying from the last received slot before dropping `from_slot` (the server may no longer have it buffered). |
 
 #### `[programs]`
 

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -30,7 +30,13 @@ pub enum RpcError {
     #[error("Processed commitment level is not supported")]
     ProcessedCommitmentNotSupported,
     #[error("Node is unhealthy")]
-    NodeUnhealthy,
+    NodeUnhealthy {
+        /// When `true`, this is surfaced as an HTTP `503 Service Unavailable`
+        /// response instead of a `200 OK` JSON-RPC error (see the
+        /// `unhealthy-response` config option). Decided at the error site from
+        /// [`CloudbreakRpcState::unhealthy_response`].
+        service_unavailable: bool,
+    },
     #[error(
         "Account {pubkey} is owned by {owner}, which is excluded from this indexer's program filter; cannot serve this account"
     )]
@@ -79,7 +85,7 @@ impl RpcError {
             RpcError::InvalidParamsWithMessage(_) => "INVALID_PARAMS_WITH_MESSAGE",
             RpcError::KeyExcludedFromSecondaryIndex { .. } => "KEY_EXCLUDED_FROM_SECONDARY_INDEX",
             RpcError::ProcessedCommitmentNotSupported => "PROCESSED_COMMITMENT_NOT_SUPPORTED",
-            RpcError::NodeUnhealthy => "NODE_UNHEALTHY",
+            RpcError::NodeUnhealthy { .. } => "NODE_UNHEALTHY",
             RpcError::AccountOwnerExcluded { .. } => "ACCOUNT_OWNER_EXCLUDED",
             RpcError::AccountNotFound { .. } => "Invalid param: could not find account",
             RpcError::NotATokenAccount { .. } => "Invalid param: not a Token account",
@@ -100,7 +106,7 @@ impl RpcError {
             RpcError::InvalidParamsWithMessage(_) => -32602,
             RpcError::KeyExcludedFromSecondaryIndex { .. } => -32010,
             RpcError::ProcessedCommitmentNotSupported => -32003,
-            RpcError::NodeUnhealthy => -32005,
+            RpcError::NodeUnhealthy { .. } => -32005,
             RpcError::AccountOwnerExcluded { .. } => -32010,
             RpcError::AccountNotFound { .. } => -32602,
             RpcError::NotATokenAccount { .. } => -32602,

--- a/crates/api/src/http/mod.rs
+++ b/crates/api/src/http/mod.rs
@@ -19,7 +19,7 @@ use solana_rpc_client_api::response::Response as RpcResponse;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 use tracing::Instrument;
-use cloudbreak_core::{AccountSelectorConfig, ProcessedCommitmentBehavior};
+use cloudbreak_core::{AccountSelectorConfig, ProcessedCommitmentBehavior, UnhealthyResponseBehavior};
 use cloudbreak_entity::slots;
 
 #[derive(Clone)]
@@ -44,6 +44,7 @@ pub struct CloudbreakRpcState {
     pub gpa_stream_batch_size: usize,
     pub request_timeout: Duration,
     pub processed_commitment: ProcessedCommitmentBehavior,
+    pub unhealthy_response: UnhealthyResponseBehavior,
     pub gpa_processor: GpaProcessor,
     pub genesis_hash: String,
     pub vote_accounts_supported: bool,
@@ -65,6 +66,7 @@ impl CloudbreakRpcState {
         gpa_stream_batch_size: usize,
         request_timeout: Duration,
         processed_commitment: ProcessedCommitmentBehavior,
+        unhealthy_response: UnhealthyResponseBehavior,
         gpa_processor: GpaProcessor,
         genesis_hash: String,
         vote_accounts_supported: bool,
@@ -82,6 +84,7 @@ impl CloudbreakRpcState {
             gpa_stream_batch_size,
             request_timeout,
             processed_commitment,
+            unhealthy_response,
             gpa_processor,
             genesis_hash,
             vote_accounts_supported,
@@ -89,6 +92,15 @@ impl CloudbreakRpcState {
             max_multiple_accounts,
             simulation_supported,
             feature_set_cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Builds a [`RpcError::NodeUnhealthy`], baking in whether it should be
+    /// surfaced as an HTTP `503` (per the `unhealthy-response` config) so the
+    /// response layer can decide the HTTP status purely from the error.
+    pub fn node_unhealthy(&self) -> RpcError {
+        RpcError::NodeUnhealthy {
+            service_unavailable: self.unhealthy_response == UnhealthyResponseBehavior::HttpUnavailable,
         }
     }
 
@@ -107,7 +119,7 @@ impl CloudbreakRpcState {
                 let data = data.read().expect("Failed to read slot syncronizer data");
 
                 if !data.is_healthy() {
-                    return Err(RpcError::NodeUnhealthy);
+                    return Err(self.node_unhealthy());
                 }
 
                 Ok((
@@ -124,7 +136,7 @@ impl CloudbreakRpcState {
                 let model = slot_model.ok_or(RpcError::InternalError)?;
 
                 if !model.health {
-                    return Err(RpcError::NodeUnhealthy);
+                    return Err(self.node_unhealthy());
                 }
 
                 Ok((model.slot as u64, model.block_time))
@@ -219,9 +231,32 @@ fn extract_param<T: serde::de::DeserializeOwned>(
 }
 
 fn make_error_response(id: serde_json::Value, code: i32, message: String) -> HttpHandlerResponse {
+    make_error_response_with_status(id, code, message, StatusCode::OK)
+}
+
+fn make_error_response_with_status(
+    id: serde_json::Value,
+    code: i32,
+    message: String,
+    status: StatusCode,
+) -> HttpHandlerResponse {
     let response = JsonRpcResponse::<()>::error(id, code, message);
     HttpHandlerResponse {
-        status: StatusCode::OK,
+        status,
         body: ResponseBody::Buffered(serde_json::to_vec(&response).unwrap()),
+    }
+}
+
+/// Maps an [`RpcError`] to the HTTP status the response should carry. Almost
+/// everything is a `200 OK` JSON-RPC error; the sole exception is an unhealthy
+/// node when `unhealthy-response = "http-unavailable"`, which is baked into the
+/// error at its source (see [`CloudbreakRpcState::node_unhealthy`]) and surfaced
+/// here as HTTP `503 Service Unavailable`.
+pub fn http_status_for_error(err: &RpcError) -> StatusCode {
+    match err {
+        RpcError::NodeUnhealthy {
+            service_unavailable: true,
+        } => StatusCode::SERVICE_UNAVAILABLE,
+        _ => StatusCode::OK,
     }
 }

--- a/crates/api/src/http/rpc.rs
+++ b/crates/api/src/http/rpc.rs
@@ -20,7 +20,8 @@ use crate::http::CloudbreakRpcState;
 use crate::http::server::{HttpHandlerResponse, ResponseBody};
 use crate::http::streaming::gpa_streaming_response_body;
 use crate::http::{
-    JsonRpcRequest, JsonRpcResponse, RpcRequestPayload, extract_param, make_error_response,
+    JsonRpcRequest, JsonRpcResponse, RpcRequestPayload, extract_param, http_status_for_error,
+    make_error_response, make_error_response_with_status,
 };
 use crate::methods::slot::RpcGetSlotConfig;
 use crate::methods::token::{
@@ -124,7 +125,7 @@ async fn process_single_request(
     let id = rpc_request.id.clone();
     let method = rpc_request.method.as_str();
 
-    let response_bytes: Vec<u8> = match method {
+    let (response_bytes, status): (Vec<u8>, StatusCode) = match method {
         "getHealth" => {
             let healthy = db_query::get_service_health(&state.database).await;
 
@@ -196,7 +197,7 @@ async fn process_single_request(
             let json_response = json_serialize_response(id, result).await;
 
             metrics::CLOUDBREAK_API_REQUEST_DURATION_MS
-                .with_label_values(&["gAI", metrics::bytes_bucket(json_response.len() as u64)])
+                .with_label_values(&["gAI", metrics::bytes_bucket(json_response.0.len() as u64)])
                 .observe(start_time.elapsed().as_millis() as f64);
 
             json_response
@@ -228,7 +229,7 @@ async fn process_single_request(
             metrics::CLOUDBREAK_API_REQUEST_DURATION_MS
                 .with_label_values(&[
                     "getBalance",
-                    metrics::bytes_bucket(json_response.len() as u64),
+                    metrics::bytes_bucket(json_response.0.len() as u64),
                 ])
                 .observe(start_time.elapsed().as_millis() as f64);
 
@@ -266,7 +267,7 @@ async fn process_single_request(
             metrics::CLOUDBREAK_API_REQUEST_DURATION_MS
                 .with_label_values(&[
                     "getMultipleAccounts",
-                    metrics::bytes_bucket(json_response.len() as u64),
+                    metrics::bytes_bucket(json_response.0.len() as u64),
                 ])
                 .observe(start_time.elapsed().as_millis() as f64);
 
@@ -291,10 +292,11 @@ async fn process_single_request(
                     metrics::CLOUDBREAK_API_REQUESTS_TOTAL
                         .with_label_values(&["gPA", "error"])
                         .inc();
-                    return make_error_response(
+                    return make_error_response_with_status(
                         id,
                         e.to_numeric_code(),
                         e.to_error_code().to_string(),
+                        http_status_for_error(&e),
                     );
                 }
             };
@@ -313,17 +315,18 @@ async fn process_single_request(
                     metrics::CLOUDBREAK_API_REQUESTS_TOTAL
                         .with_label_values(&["gPA", "error"])
                         .inc();
-                    return make_error_response(
+                    return make_error_response_with_status(
                         id,
                         e.to_numeric_code(),
                         e.to_error_code().to_string(),
+                        http_status_for_error(&e),
                     );
                 }
             };
 
             if in_batch {
                 // Await and collect the streaming body into a `Vec<u8>`
-                gpa_streamed_to_buffered(body, id).await
+                (gpa_streamed_to_buffered(body, id).await, StatusCode::OK)
             } else {
                 return HttpHandlerResponse {
                     status: StatusCode::OK,
@@ -352,10 +355,11 @@ async fn process_single_request(
                     metrics::CLOUDBREAK_API_REQUESTS_TOTAL
                         .with_label_values(&["gTABM", "error"])
                         .inc();
-                    return make_error_response(
+                    return make_error_response_with_status(
                         id,
                         e.to_numeric_code(),
                         e.to_error_code().to_string(),
+                        http_status_for_error(&e),
                     );
                 }
             };
@@ -374,16 +378,17 @@ async fn process_single_request(
                     metrics::CLOUDBREAK_API_REQUESTS_TOTAL
                         .with_label_values(&["gTABM", "error"])
                         .inc();
-                    return make_error_response(
+                    return make_error_response_with_status(
                         id,
                         e.to_numeric_code(),
                         e.to_error_code().to_string(),
+                        http_status_for_error(&e),
                     );
                 }
             };
 
             if in_batch {
-                gpa_streamed_to_buffered(body, id).await
+                (gpa_streamed_to_buffered(body, id).await, StatusCode::OK)
             } else {
                 return HttpHandlerResponse {
                     status: StatusCode::OK,
@@ -426,7 +431,7 @@ async fn process_single_request(
             metrics::CLOUDBREAK_API_REQUEST_DURATION_MS
                 .with_label_values(&[
                     "getTokenAccountBalance",
-                    metrics::bytes_bucket(json_response.len() as u64),
+                    metrics::bytes_bucket(json_response.0.len() as u64),
                 ])
                 .observe(start_time.elapsed().as_millis() as f64);
 
@@ -465,7 +470,7 @@ async fn process_single_request(
             metrics::CLOUDBREAK_API_REQUEST_DURATION_MS
                 .with_label_values(&[
                     "getTokenSupply",
-                    metrics::bytes_bucket(json_response.len() as u64),
+                    metrics::bytes_bucket(json_response.0.len() as u64),
                 ])
                 .observe(start_time.elapsed().as_millis() as f64);
 
@@ -505,7 +510,7 @@ async fn process_single_request(
             metrics::CLOUDBREAK_API_REQUEST_DURATION_MS
                 .with_label_values(&[
                     "getTokenLargestAccounts",
-                    metrics::bytes_bucket(json_response.len() as u64),
+                    metrics::bytes_bucket(json_response.0.len() as u64),
                 ])
                 .observe(start_time.elapsed().as_millis() as f64);
 
@@ -538,7 +543,7 @@ async fn process_single_request(
             let json_start_time = Instant::now();
 
             let json_response = json_serialize_response(id, response).await;
-            let response_size = json_response.len() as u64;
+            let response_size = json_response.0.len() as u64;
 
             if let Some(metrics_data) = metrics_data {
                 metrics_data.record_metrics(
@@ -584,7 +589,7 @@ async fn process_single_request(
             let json_start_time = Instant::now();
 
             let json_response = json_serialize_response(id, response).await;
-            let response_size = json_response.len() as u64;
+            let response_size = json_response.0.len() as u64;
 
             if let Some(metrics_data) = metrics_data {
                 metrics_data.record_metrics(
@@ -610,16 +615,25 @@ async fn process_single_request(
     };
 
     HttpHandlerResponse {
-        status: StatusCode::OK,
+        status,
         body: ResponseBody::Buffered(response_bytes),
     }
 }
 
+/// Serializes an RPC method result into JSON-RPC response bytes and the HTTP
+/// status the response should carry. The status is always `200 OK` except for
+/// an unhealthy node when `unhealthy-response = "http-unavailable"` (baked into
+/// the error at its source; see [`http_status_for_error`]).
 #[tracing::instrument(name = "json_encoding", skip_all)]
 async fn json_serialize_response<T: Serialize + Send + 'static>(
     id: serde_json::Value,
     result: Result<T, RpcError>,
-) -> Vec<u8> {
+) -> (Vec<u8>, StatusCode) {
+    let status = match &result {
+        Ok(_) => StatusCode::OK,
+        Err(e) => http_status_for_error(e),
+    };
+
     let res = match result {
         Ok(value) => tokio::task::spawn_blocking(move || {
             let response = JsonRpcResponse::success(id, value);
@@ -640,10 +654,12 @@ async fn json_serialize_response<T: Serialize + Send + 'static>(
         }
     };
 
-    res.unwrap_or_else(|_| {
+    let bytes = res.unwrap_or_else(|_| {
         tracing::error!("Failed to json_serialize_response");
         vec![]
-    })
+    });
+
+    (bytes, status)
 }
 
 async fn gpa_streamed_to_buffered(

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -132,6 +132,7 @@ pub async fn run(config: &str) -> cloudbreak_core::Result<()> {
         gpa_stream_batch_size,
         request_timeout,
         config.processed_commitment,
+        config.unhealthy_response,
         gpa_processor,
         config.genesis_hash.clone(),
         vote_accounts_supported,

--- a/crates/api/src/methods/vote_accounts.rs
+++ b/crates/api/src/methods/vote_accounts.rs
@@ -58,7 +58,7 @@ pub async fn get_vote_accounts(
             target: "get_vote_accounts",
             "stakes cache not yet populated; indexer has not finished a snapshot pass with stake data"
         );
-        return Err(RpcError::NodeUnhealthy);
+        return Err(state.node_unhealthy());
     }
 
     let finalized_slot = match state

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -59,6 +59,29 @@ pub struct GrpcConfig {
     ///  (it will always reconnect on a single stream `None`)
     #[serde(rename = "max-grpc-errors")]
     pub max_grpc_errors: usize,
+    /// How long to keep retrying (re)connection/subscription before giving up and panicking.
+    #[serde(
+        rename = "reconnect-give-up",
+        default = "GrpcConfig::default_reconnect_give_up",
+        deserialize_with = "deserialize_duration_required"
+    )]
+    pub reconnect_give_up: Duration,
+    /// Delay between (re)connection/subscription attempts.
+    #[serde(
+        rename = "reconnect-backoff",
+        default = "GrpcConfig::default_reconnect_backoff",
+        deserialize_with = "deserialize_duration_required"
+    )]
+    pub reconnect_backoff: Duration,
+    /// How long a reconnection keeps replaying from the last received slot (`from_slot`). Once we
+    /// have been failing for longer than this, subscribe without `from_slot` (the server may not
+    /// have it buffered).
+    #[serde(
+        rename = "reconnect-from-slot-retain",
+        default = "GrpcConfig::default_reconnect_from_slot_retain",
+        deserialize_with = "deserialize_duration_required"
+    )]
+    pub reconnect_from_slot_retain: Duration,
 }
 
 impl GrpcConfig {
@@ -78,6 +101,15 @@ impl GrpcConfig {
     }
     const fn default_max_chunk_bytes_data() -> usize {
         2 * 1024 * 1024
+    }
+    const fn default_reconnect_give_up() -> Duration {
+        Duration::from_secs(600)
+    }
+    const fn default_reconnect_backoff() -> Duration {
+        Duration::from_secs(5)
+    }
+    const fn default_reconnect_from_slot_retain() -> Duration {
+        Duration::from_secs(300)
     }
 }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -574,6 +574,18 @@ pub enum ProcessedCommitmentBehavior {
     UseConfirmed,
 }
 
+/// How the API responds when the node is unhealthy (the `slots.health` flag is
+/// unset / the slot syncronizer reports unhealthy).
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum UnhealthyResponseBehavior {
+    /// Return a JSON-RPC error (`NODE_UNHEALTHY`) with HTTP `200 OK` (default).
+    #[default]
+    JsonRpcError,
+    /// Return an HTTP `503 Service Unavailable` response instead.
+    HttpUnavailable,
+}
+
 #[derive(Deserialize, Debug)]
 pub struct ApiConfig {
     pub database: DatabaseConfig,
@@ -591,6 +603,9 @@ pub struct ApiConfig {
     pub slot_syncronizer: SlotSyncronizerConfig,
     #[serde(rename = "processed-commitment", default)]
     pub processed_commitment: ProcessedCommitmentBehavior,
+    /// How the API responds to requests while the node is unhealthy.
+    #[serde(rename = "unhealthy-response", default)]
+    pub unhealthy_response: UnhealthyResponseBehavior,
     #[serde(rename = "gpa-cache")]
     pub gpa_cache: Option<GpaCacheConfig>,
     #[serde(rename = "genesis-hash", default = "ApiConfig::default_genesis_hash")]

--- a/crates/index/src/modules/grpc.rs
+++ b/crates/index/src/modules/grpc.rs
@@ -3,6 +3,7 @@
  * Copyright 2025-2026 Triton One Limited. All rights reserved.
  */
 
+use cloudbreak_core::{EnvironmentInfo, IndexConfig};
 use futures::StreamExt;
 use sea_orm::DatabaseConnection;
 use std::{
@@ -27,7 +28,6 @@ use yellowstone_grpc_proto::{
     },
     tonic::codec::CompressionEncoding,
 };
-use cloudbreak_core::{EnvironmentInfo, IndexConfig};
 
 use crate::metrics;
 
@@ -47,7 +47,10 @@ async fn store_grpc_version(version_json: &str, db: &DatabaseConnection) {
                 tracing::error!("Failed to upsert grpc version: {:?}", e);
             }
         }
-        None => tracing::error!("Failed to parse grpc version from response: {}", version_json),
+        None => tracing::error!(
+            "Failed to parse grpc version from response: {}",
+            version_json
+        ),
     }
 }
 
@@ -55,9 +58,12 @@ async fn store_grpc_version(version_json: &str, db: &DatabaseConnection) {
 /// Spawns a background task to handle the stream and forwards updates to the buffer channel.
 /// Automatically reconnects on stream timeouts , stream `None` or errors (only after exceeding
 ///  the `max_grpc_errors` count). It also resets the is_startup flag when the connection is lost.
-const GRPC_RECONNECT_GIVE_UP: Duration = Duration::from_secs(600);
-const GRPC_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
-
+///
+/// Reconnection is governed by a single give-up window: `reconnect_failed_since` records when we
+/// started failing to (re)connect/subscribe and is only cleared once we successfully connect AND
+/// subscribe. Connect/subscribe failures log an error and `continue`; the loop backs off by
+/// `config.grpc.reconnect_backoff` between attempts and panics once the failing window exceeds
+/// `config.grpc.reconnect_give_up`.
 pub fn subscribe_grpc_with_reconnection(
     config: IndexConfig,
     buffer_channel_tx: Sender<SubscribeUpdate>,
@@ -69,13 +75,33 @@ pub fn subscribe_grpc_with_reconnection(
     tokio::spawn(async move {
         let _guard = metrics::TokioTaskCounterGuard::new("grpc");
         let mut log_first_message = true;
-        let mut connect_failed_since: Option<Instant> = None;
+        let mut reconnect_failed_since: Option<Instant> = None;
         let mut is_reconnect = false;
+
+        let give_up = config.grpc.reconnect_give_up;
+        let backoff = config.grpc.reconnect_backoff;
+        let from_slot_retain = config.grpc.reconnect_from_slot_retain;
 
         loop {
             if cancel.load(Ordering::SeqCst) {
                 tracing::info!("GRPC subscription cancelled");
                 return;
+            }
+
+            // Centralized reconnection backoff / give-up: `reconnect_failed_since` is `Some` while
+            // we are failing to (re)connect or subscribe and only cleared once both succeed.
+            if let Some(started) = reconnect_failed_since {
+                if started.elapsed() >= give_up {
+                    tracing::error!(
+                        "Failed to (re)connect to Yellowstone GRPC after {:?}",
+                        started.elapsed()
+                    );
+                    panic!(
+                        "Failed to (re)connect to Yellowstone GRPC after {:?}",
+                        started.elapsed()
+                    );
+                }
+                tokio::time::sleep(backoff).await;
             }
 
             let grpc_timeout = Duration::from_secs(config.grpc.timeout);
@@ -100,7 +126,6 @@ pub fn subscribe_grpc_with_reconnection(
                 .await
             {
                 Ok(mut c) => {
-                    connect_failed_since = None;
                     match c.get_version().await {
                         Ok(response) => store_grpc_version(&response.version, &db).await,
                         Err(e) => tracing::error!("Failed to get grpc version: {:?}", e),
@@ -108,17 +133,9 @@ pub fn subscribe_grpc_with_reconnection(
                     c
                 }
                 Err(e) => {
-                    let started = *connect_failed_since.get_or_insert_with(Instant::now);
-                    if started.elapsed() >= GRPC_RECONNECT_GIVE_UP {
-                        panic!(
-                            "Failed to connect to Yellowstone GRPC for {:?}: {:?}",
-                            started.elapsed(),
-                            e
-                        );
-                    }
+                    reconnect_failed_since.get_or_insert_with(Instant::now);
                     tracing::error!("Failed to connect to Yellowstone GRPC: {:?}", e);
                     metrics::increment_grpc_errors();
-                    tokio::time::sleep(GRPC_RECONNECT_BACKOFF).await;
                     continue;
                 }
             };
@@ -132,7 +149,12 @@ pub fn subscribe_grpc_with_reconnection(
 
             // tracing::debug!("Account include: {:?}", account_include);
 
-            let from_slot = if is_reconnect {
+            // Replay from the last received slot on reconnect, but only while we have been failing
+            // for less than `from_slot_retain`; after that, drop it since the server may no longer
+            // have that slot buffered.
+            let keep_from_slot =
+                reconnect_failed_since.is_none_or(|started| started.elapsed() < from_slot_retain);
+            let from_slot = if is_reconnect && keep_from_slot {
                 let last = *last_slot_received
                     .lock()
                     .expect("Failed to lock last_slot_received");
@@ -170,32 +192,32 @@ pub fn subscribe_grpc_with_reconnection(
             };
 
             let (_sub_tx, stream) = match client
-                .subscribe_with_request(Some(blocks_subscribe_request.clone()))
+                .subscribe_with_request(Some(blocks_subscribe_request))
                 .await
             {
                 Ok(subscription) => {
                     if let Some(slot) = from_slot {
-                        tracing::info!("Reconnected to Yellowstone GRPC replaying from slot {}", slot);
+                        tracing::info!(
+                            "Reconnected to Yellowstone GRPC replaying from slot {}",
+                            slot
+                        );
                     }
                     subscription
                 }
-                Err(e) if from_slot.is_some() => {
+                Err(e) => {
+                    reconnect_failed_since.get_or_insert_with(Instant::now);
                     tracing::error!(
-                        "Failed to subscribe to Yellowstone GRPC with from_slot {:?}, retrying without it: {:?}",
+                        "Failed to subscribe to Yellowstone GRPC (from_slot {:?}): {:?}",
                         from_slot,
                         e
                     );
                     metrics::increment_grpc_errors();
-                    client
-                        .subscribe_with_request(Some(SubscribeRequest {
-                            from_slot: None,
-                            ..blocks_subscribe_request
-                        }))
-                        .await
-                        .expect("Failed to subscribe to Yellowstone GRPC")
+                    continue;
                 }
-                Err(e) => panic!("Failed to subscribe to Yellowstone GRPC: {:?}", e),
             };
+
+            // Connected and subscribed: reset the give-up window.
+            reconnect_failed_since = None;
 
             let buffer_channel_rx_len_clone = buffer_channel_rx_len.clone();
             let mut grpc_current_errors = 0;

--- a/example.cloudbreak.api-with-query-tracker-client.toml
+++ b/example.cloudbreak.api-with-query-tracker-client.toml
@@ -20,6 +20,13 @@ flush-interval = "1m"
 # "use-confirmed" — silently respond with confirmed data instead.
 # processed-commitment = "reject"
 
+# How to respond to requests while the node is unhealthy.
+# "json-rpc-error" (default) — return a NODE_UNHEALTHY JSON-RPC error with HTTP 200.
+# "http-unavailable" — return an HTTP 503 Service Unavailable response instead.
+#   (Note: only applies to single requests; batch requests always return HTTP 200
+#    with per-item JSON-RPC errors.)
+# unhealthy-response = "json-rpc-error"
+
 [tracing]
 enabled = true
 endpoint = "http://localhost:4317"

--- a/example.cloudbreak.api.toml
+++ b/example.cloudbreak.api.toml
@@ -58,6 +58,13 @@ span-filter = [
 # "use-confirmed" — silently respond with confirmed data instead.
 # processed-commitment = "reject"
 
+# How to respond to requests while the node is unhealthy.
+# "json-rpc-error" (default) — return a NODE_UNHEALTHY JSON-RPC error with HTTP 200.
+# "http-unavailable" — return an HTTP 503 Service Unavailable response instead.
+#   (Note: only applies to single requests; batch requests always return HTTP 200
+#    with per-item JSON-RPC errors.)
+# unhealthy-response = "json-rpc-error"
+
 [slot-syncronizer]
 enabled = false
 interval_ms = 200

--- a/example.cloudbreak.index.toml
+++ b/example.cloudbreak.index.toml
@@ -45,6 +45,12 @@ max-chunk-bytes-data = 2097152
 max-grpc-errors = 1
 # The buffer size for queuing subscription events
 channel-size = 1000
+# How long to keep retrying (re)connection/subscription before giving up and panicking
+reconnect-give-up = "600s"
+# Delay between (re)connection/subscription attempts
+reconnect-backoff = "5s"
+# How long a reconnection keeps replaying from the last received slot before dropping from_slot
+reconnect-from-slot-retain = "300s"
 
 [metrics]
 host = "0.0.0.0"


### PR DESCRIPTION
## Summary

Two related operability improvements, both fully configurable with
backwards-compatible defaults:

1. **Configurable gRPC reconnection (indexer).** The Yellowstone gRPC
   reconnection loop's give-up window, backoff, and `from_slot` replay
   retention are now driven by config instead of hard-coded constants, and
   subscribe failures now flow through the same centralized give-up/backoff
   path (with error logging) as connect failures instead of panicking on the
   spot.
2. **Configurable node-unhealthy response (API).** When the node is unhealthy,
   the API can now optionally return an HTTP `503 Service Unavailable` instead
   of the default `200 OK` JSON-RPC `NODE_UNHEALTHY` error.


## gRPC reconnection (`crates/index`, `crates/core`)

- Replaced the hard-coded `GRPC_RECONNECT_GIVE_UP` (600s) / `GRPC_RECONNECT_BACKOFF` (5s) constants with three `[grpc]` config keys:
  - `reconnect-give-up` (default `600s`) — how long to keep retrying before giving up and panicking.
  - `reconnect-backoff` (default `5s`) — delay between attempts.
  - `reconnect-from-slot-retain` (default `300s`) — how long a reconnection keeps replaying from the last received slot before dropping `from_slot` (the server may no longer have it buffered).
- Centralized reconnection handling: a single `reconnect_failed_since` window now governs both connect **and** subscribe failures. It is only cleared once we successfully connect *and* subscribe, so persistent subscribe failures now count toward the give-up window (previously the timer reset on every successful connect, so subscribe failures could hot-loop forever).
- Subscribe failures now log an error, increment the error metric, and `continue` (letting the outer loop back off / eventually panic) instead of panicking inline. This also fixes the previous fallback path that dropped the underlying error via `.expect(...)`.
- `from_slot` is retained on reconnect only while we've been failing for less than `reconnect-from-slot-retain`, then dropped.

## Node-unhealthy response (`crates/api`, `crates/core`)

- New top-level API config key `unhealthy-response`:
  - `"json-rpc-error"` (default) — `NODE_UNHEALTHY` JSON-RPC error (code `-32005`) with HTTP `200 OK` (unchanged behavior).
  - `"http-unavailable"` — HTTP `503 Service Unavailable`.
- The decision is baked into the error at its source: `RpcError::NodeUnhealthy { service_unavailable }` is constructed via `CloudbreakRpcState::node_unhealthy()` (reads the config), and the response layer derives the HTTP status purely from the error variant — no config plumbing through the request handlers.
- **Limitation (documented):** applies to single requests only. Batch requests always return HTTP `200 OK` with per-item JSON-RPC errors, since an HTTP status can't be expressed per batch item.

## Docs

- README: documented the three new `[grpc]` keys and the `unhealthy-response` key (with the batch caveat).
- Updated `example.cloudbreak.index.toml`, `example.cloudbreak.api.toml`, and `example.cloudbreak.api-with-query-tracker-client.toml`.